### PR TITLE
Update TomoCollect_settings.req

### DIFF
--- a/docs/demo/13bm/TomoCollect_settings.req
+++ b/docs/demo/13bm/TomoCollect_settings.req
@@ -47,6 +47,8 @@ $(P)$(R)ExposureTime
 $(P)$(R)FilePath
 $(P)$(R)FileName
 $(P)$(R)ScanStatus
+$(P)$(R)ScanReady
+$(P)$(R)ScanStart
 $(P)$(R)ScanPoint
 $(P)$(R)ElapsedTime
 $(P)$(R)RemainingTime


### PR DESCRIPTION
missing ScanReady, ScanStart, MoveSampleIn, MoveSampleOut, RotationStop

Also: are the TomoCollect template and settings automatically generated? 

If not do you mind if I sort them to match the doc (Required, Server mode, Optional)?