### PR TITLE
Set location in HDF5 file and improve base class

### DIFF
--- a/tomoScanApp/Db/tomoScan.template
+++ b/tomoScanApp/Db/tomoScan.template
@@ -219,7 +219,7 @@ record(stringout, "$(P)$(R)HDF5DarkLocation")
 }
 record(stringout, "$(P)$(R)HDF5FlatLocation")
 {
-   field(VAL, "/exchange/data_flat")
+   field(VAL, "/exchange/data_white")
 }
 record(stringout, "$(P)$(R)HDF5Location")
 {

--- a/tomoScanApp/Db/tomoScan.template
+++ b/tomoScanApp/Db/tomoScan.template
@@ -209,6 +209,23 @@ record(bi, "$(P)$(R)FilePathExists")
     field(OSV,  "NO_ALARM")
 }
 
+record(stringout, "$(P)$(R)HDF5DataLocation")
+{
+   field(VAL, "/exchange/data")
+}
+record(stringout, "$(P)$(R)HDF5DarkLocation")
+{
+   field(VAL, "/exchange/data_dark")
+}
+record(stringout, "$(P)$(R)HDF5FlatLocation")
+{
+   field(VAL, "/exchange/data_flat")
+}
+record(stringout, "$(P)$(R)HDF5Location")
+{
+}
+
+
 #################################
 # Scan control via Channel Access
 #################################

--- a/tomoScanApp/Db/tomoScan.template
+++ b/tomoScanApp/Db/tomoScan.template
@@ -209,7 +209,7 @@ record(bi, "$(P)$(R)FilePathExists")
     field(OSV,  "NO_ALARM")
 }
 
-record(stringout, "$(P)$(R)HDF5DataLocation")
+record(stringout, "$(P)$(R)HDF5ProjectionLocation")
 {
    field(VAL, "/exchange/data")
 }

--- a/tomoScanApp/Db/tomoScan_settings.req
+++ b/tomoScanApp/Db/tomoScan_settings.req
@@ -70,7 +70,7 @@ $(P)$(R)ExposureTime
 $(P)$(R)FilePath
 $(P)$(R)FileName
 #controlPV $(P)$(R)FilePathExists
-#controlPV $(P)$(R)HDF5DataLocation
+#controlPV $(P)$(R)HDF5ProjectionLocation
 #controlPV $(P)$(R)HDF5DarkLocation
 #controlPV $(P)$(R)HDF5FlatLocation
 #controlPV $(P)$(R)HDF5Location

--- a/tomoScanApp/Db/tomoScan_settings.req
+++ b/tomoScanApp/Db/tomoScan_settings.req
@@ -70,6 +70,10 @@ $(P)$(R)ExposureTime
 $(P)$(R)FilePath
 $(P)$(R)FileName
 #controlPV $(P)$(R)FilePathExists
+#controlPV $(P)$(R)HDF5DataLocation
+#controlPV $(P)$(R)HDF5DarkLocation
+#controlPV $(P)$(R)HDF5FlatLocation
+#controlPV $(P)$(R)HDF5Location
 
 #################################
 # Scan control via Channel Access

--- a/tomoscan/tomoscan.py
+++ b/tomoscan/tomoscan.py
@@ -100,8 +100,10 @@ class TomoScan():
         self.control_pvs['FPNumCaptured']     = PV(prefix + 'NumCaptured_RBV')
         self.control_pvs['FPCapture']         = PV(prefix + 'Capture')
         self.control_pvs['FPFilePath']        = PV(prefix + 'FilePath')
+        self.control_pvs['FPFilePathRBV']     = PV(prefix + 'FilePath_RBV')
         self.control_pvs['FPFilePathExists']  = PV(prefix + 'FilePathExists_RBV')
         self.control_pvs['FPFileName']        = PV(prefix + 'FileName')
+        self.control_pvs['FPFileNameRBV']     = PV(prefix + 'FileName_RBV')
         self.control_pvs['FPFileNumber']      = PV(prefix + 'FileNumber')
         self.control_pvs['FPAutoIncrement']   = PV(prefix + 'AutoIncrement')
         self.control_pvs['FPFullFileName']    = PV(prefix + 'FullFileName_RBV')
@@ -521,26 +523,18 @@ class TomoScan():
             self.begin_scan()
             # Collect the pre-scan dark fields if required
             if (num_dark_fields > 0) and (dark_field_mode in ('Start', 'Both')):
-                self.close_shutter()
-                self.collect_dark_fields()
-            # Open the shutter
-            self.open_shutter()
+               self.collect_dark_fields()
             # Collect the pre-scan flat fields if required
             if (num_flat_fields > 0) and (flat_field_mode in ('Start', 'Both')):
-                self.move_sample_out()
-                self.collect_flat_fields()
+               self.collect_flat_fields()
             # Collect the projections
-            self.move_sample_in()
             self.collect_projections()
             # Collect the post-scan flat fields if required
             if (num_flat_fields > 0) and (flat_field_mode in ('End', 'Both')):
-                self.move_sample_out()
                 self.collect_flat_fields()
-                self.move_sample_in()
             # Collect the post-scan dark fields if required
             if (num_dark_fields > 0) and (dark_field_mode in ('End', 'Both')):
-                self.close_shutter()
-                self.collect_dark_fields()
+               self.collect_dark_fields()
 
         except ScanAbortError:
             logging.error('Scan aborted')
@@ -557,16 +551,67 @@ class TomoScan():
         thread.start()
 
     def collect_dark_fields(self):
-        """Base class implementation of this function just prints an error"""
-        logging.error('collect_dark_fields is not implemented in %s', type(self).__name__)
+        """Collects dark field data
+
+        This base class method does the following:
+
+          - Sets the scan status message
+
+          - Calls close_shutter()
+
+          - Sets the HDF5 data location for dark fields
+
+        Derived classes must override this method to actually collect the dark fields.
+        In most cases they should call this base class method first and then perform
+        the beamline-specific operations.
+        """
+        self.epics_pvs['ScanStatus'].put('Collecting dark fields')
+        self.close_shutter()
+        self.epics_pvs['HDF5Location'].put(self.epics_pvs['HDF5DarkLocation'].value)
 
     def collect_flat_fields(self):
-        """Base class implementation of this function just prints an error"""
-        logging.error('collect_flat_fields is not implemented in %s', type(self).__name__)
+        """Collects flat field data
+
+        This base class method does the following:
+
+          - Sets the scan status message
+
+          - Calls open_shutter()
+
+          - Calls move_sample_out()
+
+          - Sets the HDF5 data location for flat fields
+
+        Derived classes must override this method to actually collect the flat fields.
+        In most cases they should call this base class method first and then perform
+        the beamline-specific operations.
+        """
+        self.epics_pvs['ScanStatus'].put('Collecting flat fields')
+        self.open_shutter()
+        self.move_sample_out()
+        self.epics_pvs['HDF5Location'].put(self.epics_pvs['HDF5FlatLocation'].value)
 
     def collect_projections(self):
-        """Base class implementation of this function just prints an error"""
-        logging.error('collect_projections is not implemented in %s', type(self).__name__)
+        """Collects projection data
+
+        This base class method does the following:
+
+          - Sets the scan status message
+
+          - Calls open_shutter()
+
+          - Calls move_sample_in()
+
+          - Sets the HDF5 data location for projection data
+
+        Derived classes must override this method to actually collect the projections.
+        In most cases they should call this base class method first and then perform
+        the beamline-specific operations.
+        """
+        self.epics_pvs['ScanStatus'].put('Collecting projections')
+        self.open_shutter()
+        self.move_sample_in()
+        self.epics_pvs['HDF5Location'].put(self.epics_pvs['HDF5DataLocation'].value)
 
     def abort_scan(self):
         """Aborts a scan that is running.

--- a/tomoscan/tomoscan.py
+++ b/tomoscan/tomoscan.py
@@ -611,7 +611,7 @@ class TomoScan():
         self.epics_pvs['ScanStatus'].put('Collecting projections')
         self.open_shutter()
         self.move_sample_in()
-        self.epics_pvs['HDF5Location'].put(self.epics_pvs['HDF5DataLocation'].value)
+        self.epics_pvs['HDF5Location'].put(self.epics_pvs['HDF5ProjectionLocation'].value)
 
     def abort_scan(self):
         """Aborts a scan that is running.

--- a/tomoscan/tomoscan_13bm.py
+++ b/tomoscan/tomoscan_13bm.py
@@ -141,8 +141,8 @@ class TomoScan13BM(TomoScan):
         """
 
         # Save the configuration
-        file_path = self.epics_pvs['FilePath'].get(as_string=True)
-        file_name = self.epics_pvs['FileName'].get(as_string=True)
+        file_path = self.epics_pvs['FPFilePathRBV'].get(as_string=True)
+        file_name = self.epics_pvs['FPFileNameRBV'].get(as_string=True)
         self.save_configuration(file_path + file_name + '.config')
         # Put the camera back in FreeRun mode and acquiring
         self.set_trigger_mode('FreeRun', 1)
@@ -161,7 +161,7 @@ class TomoScan13BM(TomoScan):
         by the ``NumDarkFields`` PV.
         """
 
-        self.epics_pvs['ScanStatus'].put('Collecting dark fields')
+        super().collect_dark_fields()
         self.collect_static_frames(self.epics_pvs['NumDarkFields'].value)
 
     def collect_flat_fields(self):
@@ -170,8 +170,7 @@ class TomoScan13BM(TomoScan):
         Calls ``collect_static_frames()`` with the number of images specified
         by the ``NumFlatFields`` PV.
         """
-
-        self.epics_pvs['ScanStatus'].put('Collecting flat fields')
+        super().collect_flat_fields()
         self.collect_static_frames(self.epics_pvs['NumFlatFields'].value)
 
     def collect_projections(self):
@@ -203,7 +202,7 @@ class TomoScan13BM(TomoScan):
         - Calls ``wait_camera_done()``.
         """
 
-        self.epics_pvs['ScanStatus'].put('Collecting projections')
+        super().collect_projections()
         rotation_start = self.epics_pvs['RotationStart'].value
         rotation_step = self.epics_pvs['RotationStep'].value
         num_angles = self.epics_pvs['NumAngles'].value


### PR DESCRIPTION
This PR implements the solution to #27.

It adds the following records to tomoScan.template
```

record(stringout, "$(P)$(R)HDF5ProjectionLocation")
{
   field(VAL, "/exchange/data")
}
record(stringout, "$(P)$(R)HDF5DarkLocation")
{
   field(VAL, "/exchange/data_dark")
}
record(stringout, "$(P)$(R)HDF5FlatLocation")
{
   field(VAL, "/exchange/data_white")
}
record(stringout, "$(P)$(R)HDF5Location")
{
}
```
The base class implementations of collect_flat_fields(), collect_dark_fields(), and collect_projections() copy the appropriate PV (e.g. $(P)$(R)HDF5FlatLocation) into $(P)$(R)HDF5Location.  That latter PV is the one that controls the location in the HDF5 file.  Users can change where the data is stored by modifying $(P)$(R)HDF5FlatLocation if they want to.

tomoscan_13bm.py has been modifed to call those base class functions at the start of the derived class functions.

I have tested that this PR works correctly.  To do that I had to add this line to my detector attributes XML file
```
    <Attribute name="HDF5FrameLocation"             type="EPICS_PV"     source="$(TS)HDF5Location"                       dbrtype="DBR_STRING"  description="Where to store frame in HDF5 file"/>
```

I changed my HDF5 layout XML file to start with this:
```
<hdf5_layout>
  <global name="detector_data_destination" ndattribute="HDF5FrameLocation" />
    <group name="exchange">
```
All I did was change the ndattribute from FrameType to HDF5FrameLocation".  

I think this solution is clearer and cleaner.
