### PR TITLE
Fix docs

### DIFF
--- a/docs/source/demo.rst
+++ b/docs/source/demo.rst
@@ -5,9 +5,11 @@ Demonstation code
 scan_demo.py
 ------------
 
-:download:`scan_demo.py <../../demo/scan_demo.py>` is a simple program that demonstrates 
+scan_demo.py is a simple program that demonstrates 
 scanning an EPICS PV and collecting a complete tomography dataset at each point in the scan.  
 The EPICS PV to be scanned could be anything, such as the sample height, sample temperature, etc.
+
+.. literalinclude:: ../../demo/scan_demo.py
 
 The following shows how the program is run, and the output.  In this case EPICS motor 13BMD:m90
 was scanned from position 5.0, incrementing by 1.0, for 5 points:

--- a/docs/source/example_application.rst
+++ b/docs/source/example_application.rst
@@ -2,6 +2,16 @@
 tomoScanApp EPICS application
 =============================
 
+.. toctree::
+   :hidden:
+
+   tomoScan.template
+   tomoScan_13BM.template
+   tomoScan_settings.req
+   tomoScan_13BM_settings.req
+   tomoScan.substitutions
+
+
 tomoscan includes a complete example EPICS application, including:
 
 - A database file that contains only the PVs required by the tomoscan.py base class

--- a/docs/source/example_application.rst
+++ b/docs/source/example_application.rst
@@ -5,17 +5,17 @@ tomoScanApp EPICS application
 tomoscan includes a complete example EPICS application, including:
 
 - A database file that contains only the PVs required by the tomoscan.py base class
-  :download:`tomoScan.template <../../tomoScanApp/Db/tomoScan.template>`
+  :doc:`tomoScan.template`.
 - A corresponding autosave request file
-  :download:`tomoScan_settings.req <../../tomoScanApp/Db/tomoScan_settings.req>`.
+  :doc:`tomoScan_settings.req`.
 - A database file that contains PVs used by the tomoscan_13bm derived class
-  :download:`tomoScan_13BM.template <../../tomoScanApp/Db/tomoScan_13BM.template>`
+  :doc:`tomoScan_13BM.template`.
 - A corresponding autosave request file
-  :download:`tomoScan_13BM_settings.req <../../tomoScanApp/Db/tomoScan_13BM_settings.req>`.
+  :doc:`tomoScan_13BM_settings.req`.
 - OPI screens for medm, edm, caQtDM, CSS/Boy, and CSS/Phoebus
 - An example IOC application that can be used to run the above databases.
   The databases are loaded in the IOC with the example substitutions file, 
-  :download:`tomoScan.substitutions <../../iocBoot/iocTomoScan/tomoScan.substitutions>`.
+  :doc:`tomoScan.substitutions`.
 
 The following tables list all of the records in the tomoScan.template file.
 These records are used by the tomoscan base class and so are required.

--- a/docs/source/tomoScan.substitutions.rst
+++ b/docs/source/tomoScan.substitutions.rst
@@ -1,0 +1,3 @@
+tomoScan.substitutions
+======================
+.. literalinclude:: ../../iocBoot/iocTomoScan/tomoScan.substitutions

--- a/docs/source/tomoScan.template.rst
+++ b/docs/source/tomoScan.template.rst
@@ -1,0 +1,3 @@
+tomoScan.template
+=================
+.. literalinclude:: ../../tomoScanApp/Db/tomoScan.template

--- a/docs/source/tomoScan_13BM.template.rst
+++ b/docs/source/tomoScan_13BM.template.rst
@@ -1,0 +1,4 @@
+tomoScan_13BM.template
+======================
+.. literalinclude:: ../../tomoScanApp/Db/tomoScan_13BM.template
+

--- a/docs/source/tomoScan_13BM_settings.req.rst
+++ b/docs/source/tomoScan_13BM_settings.req.rst
@@ -1,0 +1,3 @@
+tomoScan_13BM_settings.req
+==========================
+.. literalinclude:: ../../tomoScanApp/Db/tomoScan_13BM_settings.req

--- a/docs/source/tomoScan_settings.req.rst
+++ b/docs/source/tomoScan_settings.req.rst
@@ -1,0 +1,4 @@
+tomoScan_settings.req
+=====================
+.. literalinclude:: ../../tomoScanApp/Db/tomoScan_settings.req
+


### PR DESCRIPTION
Fixes #41 

Also puts scan_demo.py directly inline as a .literalinclude in demo.rst.
