### PR TITLE
Move sample fix

### DIFF
--- a/tomoScanApp/Db/tomoScan.template
+++ b/tomoScanApp/Db/tomoScan.template
@@ -266,13 +266,13 @@ record(stringout, "$(P)$(R)HDF5Location")
 # Scan control via Channel Access
 #################################
 
-record(bo, "$(P)$(R)MoveSampleIn")
+record(busy, "$(P)$(R)MoveSampleIn")
 {
    field(ZNAM, "Done")
    field(ONAM, "Move")
 }
 
-record(bo, "$(P)$(R)MoveSampleOut")
+record(busy, "$(P)$(R)MoveSampleOut")
 {
    field(ZNAM, "Done")
    field(ONAM, "Move")

--- a/tomoScanApp/op/adl/tomoScan.adl
+++ b/tomoScanApp/op/adl/tomoScan.adl
@@ -1,6 +1,6 @@
 
 file {
-	name="/home/epics/scratch/tomoScan/tomoScanApp/op/adl/tomoScan.adl"
+	name="/home/epics/support/tomoscan/tomoScanApp/op/adl/tomoScan.adl"
 	version=030109
 }
 display {
@@ -1217,7 +1217,6 @@ menu {
 	}
 	label="Move Sample In"
 	press_msg="1"
-	release_msg="0"
 }
 "message button" {
 	object {
@@ -1233,7 +1232,6 @@ menu {
 	}
 	label="Move Sample Out"
 	press_msg="1"
-	release_msg="0"
 }
 text {
 	object {

--- a/tomoscan/tomoscan.py
+++ b/tomoscan/tomoscan.py
@@ -404,6 +404,8 @@ class TomoScan():
             position = self.epics_pvs['SampleInY'].value
             self.epics_pvs['SampleY'].put(position, wait=True)
 
+        self.epics_pvs['MoveSampleIn'].put('Done')
+
     def move_sample_out(self):
         """Moves the sample to the out of beam position for collecting flat fields.
 
@@ -422,6 +424,8 @@ class TomoScan():
         if axis in ('Y', 'Both'):
             position = self.epics_pvs['SampleOutY'].value
             self.epics_pvs['SampleY'].put(position, wait=True)
+
+        self.epics_pvs['MoveSampleOut'].put('Done')
 
     def save_configuration(self, file_name):
         """Saves the current configuration PVs to a file.


### PR DESCRIPTION
This changes the MoveSampleIn and MoveSampleOut record types from `bo` to `busy`.  They do not go back to `Done` until the motion is complete.  This allows them to be conveniently used from external scripts.