### PR TITLE
Update to include tomoscan_pso and to fix warnings and errors

### DIFF
--- a/docs/source/api/tomoscan_13bm_mcs.rst
+++ b/docs/source/api/tomoscan_13bm_mcs.rst
@@ -1,5 +1,5 @@
 :mod:`tomoscan.tomoscan_13bm_mcs`
-=============================
+=================================
 
 .. automodule:: tomoscan.tomoscan_13bm_mcs
    :members:

--- a/docs/source/api/tomoscan_13bm_pso.rst
+++ b/docs/source/api/tomoscan_13bm_pso.rst
@@ -1,5 +1,5 @@
 :mod:`tomoscan.tomoscan_13bm_pso`
-=============================
+=================================
 
 .. automodule:: tomoscan.tomoscan_13bm_pso
    :members:

--- a/docs/source/api/tomoscan_pso.rst
+++ b/docs/source/api/tomoscan_pso.rst
@@ -1,5 +1,5 @@
 :mod:`tomoscan.tomoscan_pso`
-========================
+============================
 
 .. automodule:: tomoscan.tomoscan_pso
    :members:

--- a/docs/source/tomoScan_13BM_MCS.template.rst
+++ b/docs/source/tomoScan_13BM_MCS.template.rst
@@ -1,4 +1,4 @@
 tomoScan_13BM_MCS.template
-======================
+==========================
 .. literalinclude:: ../../tomoScanApp/Db/tomoScan_13BM_MCS.template
 

--- a/docs/source/tomoScan_13BM_PSO.template.rst
+++ b/docs/source/tomoScan_13BM_PSO.template.rst
@@ -1,4 +1,4 @@
 tomoScan_13BM_PSO.template
-======================
+==========================
 .. literalinclude:: ../../tomoScanApp/Db/tomoScan_13BM_PSO.template
 

--- a/docs/source/tomoScan_PSO.template.rst
+++ b/docs/source/tomoScan_PSO.template.rst
@@ -1,3 +1,3 @@
 tomoScan_PSO.template
-=================
+=====================
 .. literalinclude:: ../../tomoScanApp/Db/tomoScan_PSO.template

--- a/docs/source/tomoScan_PSO_settings.req.rst
+++ b/docs/source/tomoScan_PSO_settings.req.rst
@@ -1,4 +1,4 @@
 tomoScan_PSO_settings.req
-=====================
+=========================
 .. literalinclude:: ../../tomoScanApp/Db/tomoScan_PSO_settings.req
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -19,10 +19,10 @@ for image N when the trigger  for image N+1 arrives.
 
 ::
 
-ts = TomoScan13BM_PSO(["../../db/tomoScan_settings.req",
-                       "../../db/tomoScan_PSO_settings.req",
-                       "../../db/tomoScan_13BM_settings.req"],
-                      {"$(P)":"13BMDPG1:", "$(R)":"TS:"})
+  ts = TomoScan13BM_PSO(["../../db/tomoScan_settings.req",
+                         "../../db/tomoScan_PSO_settings.req",
+                         "../../db/tomoScan_13BM_settings.req"],
+                        {"$(P)":"13BMDPG1:", "$(R)":"TS:"})
 
 This line creates the TomoScan13BM_PSO object.  It takes two arguments that are passed to the 
 TomoScan constructor:


### PR DESCRIPTION
This updates the documentation to include tomoscan_pso.

I am getting one error when I build the documentation that I don't understand:
```
/home/epics/support/tomoscan/docs/source/api/tomoscan_pso.rst:11: WARNING: failed to import tomoscan_pso
```
