### PR TITLE
Fix grasshopper3

### DIFF
--- a/tomoscan/tomoscan_13bm_pso.py
+++ b/tomoscan/tomoscan_13bm_pso.py
@@ -55,9 +55,22 @@ class TomoScan13BM_PSO(TomoScanPSO):
             self.epics_pvs['CamImageMode'].put('Multiple')
             self.epics_pvs['CamNumImages'].put(num_images, wait=True)
         else: # set camera to external triggering
-            self.epics_pvs['CamImageMode'].put('Multiple', wait=True)
             self.epics_pvs['CamNumImages'].put(num_images, wait=True)
             self.epics_pvs['CamTriggerMode'].put('On', wait=True)
             self.epics_pvs['CamExposureMode'].put('Timed', wait=True)
             self.epics_pvs['CamTriggerOverlap'].put('ReadOut', wait=True)
- 
+            # There is a problem with the Grasshopper3 when switching to external trigger mode.
+            # The first 3 images are bad, at least at long exposure times.
+            # We take 3 dummy frames with Software trigger mode and don't save them to HDF5 file.
+            self.epics_pvs['CamImageMode'].put('Single', wait=True)
+            self.epics_pvs['CamTriggerSource'].put('Software', wait=True)
+            exposure = self.epics_pvs['CamAcquireTimeRBV'].value
+            self.epics_pvs['FPEnableCallbacks'].put('Disable', wait=True)
+            for i in range(3):
+                self.epics_pvs['CamAcquire'].put('Acquire')
+                time.sleep(.1)
+                self.epics_pvs['CamTriggerSoftware'].put(1, wait=True)
+                self.wait_camera_done(exposure + 5)
+            self.epics_pvs['FPEnableCallbacks'].put('Enable', wait=True)
+            self.epics_pvs['CamImageMode'].put('Multiple', wait=True)
+            self.epics_pvs['CamTriggerSource'].put('Line0', wait=True)


### PR DESCRIPTION
This PR does the following:

- Improves the algorithm in tomoscan.compute_frame_time.  This is working on the Grasshopper3 with frame times of .001 to 2.0 seconds
- Fixes tomoscan_13bm_pso to take 3 dummy frames on the Grasshopper3 when changing to External Trigger mode.
- Change the Scan Status message to alter the user that an overwrite request dialog box is pending.  This is easy to miss, and the user is left wondering why the scan appears to be hung.