### PR TITLE
adding option to control xml file names

### DIFF
--- a/tomoscan/tomoscan.py
+++ b/tomoscan/tomoscan.py
@@ -113,6 +113,7 @@ class TomoScan():
         self.control_pvs['CamBinY']              = PV(camera_prefix + 'BinY')
         self.control_pvs['CamWaitForPlugins']    = PV(camera_prefix + 'WaitForPlugins')
         self.control_pvs['PortNameRBV']          = PV(camera_prefix + 'PortName_RBV')
+        self.control_pvs['CamNDAttributesFile']  = PV(camera_prefix + 'NDAttributesFile')
 
         # If this is a Point Grey camera then assume we are running ADSpinnaker
         # and create some PVs specific to that driver
@@ -151,8 +152,8 @@ class TomoScan():
         self.control_pvs['FPFullFileName']    = PV(prefix + 'FullFileName_RBV')
         self.control_pvs['FPAutoSave']        = PV(prefix + 'AutoSave')
         self.control_pvs['FPEnableCallbacks'] = PV(prefix + 'EnableCallbacks')
-        
-         
+        self.control_pvs['FPXMLFileName']     = PV(prefix + 'XMLFileName')
+
         # Set some initial PV values
         file_path = self.config_pvs['FilePath'].get(as_string=True)
         self.control_pvs['FPFilePath'].put(file_path)

--- a/tomoscan/tomoscan_2bm.py
+++ b/tomoscan/tomoscan_2bm.py
@@ -168,9 +168,11 @@ class TomoScan2BM(TomoScanPSO):
 
         This does the following:
 
-        - Calls the base class method.
-        
         - Set data directory.
+
+        - Set the TomoScan xml files
+
+        - Calls the base class method.
         
         - Opens the front-end shutter.
 
@@ -186,6 +188,10 @@ class TomoScan2BM(TomoScanPSO):
         file_path = self.epics_pvs['DetectorTopDir'].get(as_string=True) + self.epics_pvs['ExperimentYearMonth'].get(as_string=True) + os.path.sep + self.epics_pvs['UserLastName'].get(as_string=True) + os.path.sep
         self.epics_pvs['FilePath'].put(file_path, wait=True)
 
+        # set TomoScan xml files
+        self.epics_pvs['CamNDAttributesFile'].put('TomoScanDetectorAttributes.xml')
+        self.epics_pvs['FPXMLFileName'].put('TomoScanLayout.xml')
+
         # Call the base class method
         super().begin_scan()
         # Opens the front-end shutter
@@ -195,6 +201,7 @@ class TomoScan2BM(TomoScanPSO):
         # self.theta = []
         # self.theta = self.epics_pvs['ThetaArray'].get(count=int(self.num_angles))
         print(self.theta,self.num_angles)
+        print(len(self.theta))
 
     def end_scan(self):
         """Performs the operations needed at the very end of a scan.


### PR DESCRIPTION
I need this feature to switch between regular scan (tomoScan) and streaming (tomoScanStream) without having to turn off the tomoScan/tomoScanSteam epics&python servers.
@MarkRivers touches tomoscan.py to add PVs pointing to the xml file name, should have no effect on others.