### PR TITLE
Update conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -164,13 +164,13 @@ html_theme_options = {'includehidden': False}
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+# html_context = {
+#    'css_files': [
+#        '_static/theme_overrides.css',  # override wide tables in RTD theme
+#        ],
+#     }
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
Solves #107 
- removed path to non-existent custom static directory. It looks  latest docs builder is less forgiving.
- disable pdf generation (Overfull error paragraph too wide. I suspect the new tables are too large). This only affects pdf download. Web pages are OK.