### PR TITLE
13bm fixes

### DIFF
--- a/iocBoot/iocTomoScan_13BM_MCS/st.cmd
+++ b/iocBoot/iocTomoScan_13BM_MCS/st.cmd
@@ -1,18 +1,13 @@
 < envPaths
 
-epicsEnvSet("P", "TSTest:")
-epicsEnvSet("R", "TS1:")
+epicsEnvSet("P", "13BMDPG2:")
+epicsEnvSet("R", "TS:")
 
 ## Register all support components
 
 # Use these lines to run the locally built tomoScanApp
 dbLoadDatabase "../../dbd/tomoScanApp.dbd"
 tomoScanApp_registerRecordDeviceDriver pdbbase
-
-# Use these lines to run the xxx application on APSshare.
-#dbLoadDatabase "/APSshare/epics/synApps_6_1/support/xxx-R6-1/dbd/iocxxxLinux.dbd"
-#iocxxxLinux_registerRecordDeviceDriver pdbbase
-
 
 dbLoadTemplate("tomoScan.substitutions")
 

--- a/iocBoot/iocTomoScan_13BM_MCS/start_IOC
+++ b/iocBoot/iocTomoScan_13BM_MCS/start_IOC
@@ -1,6 +1,3 @@
 # Use this line to run the locally built tomoScanApp
 ../../bin/linux-x86_64/tomoScanApp st.cmd
 
-# Use this line to run the xxx application on /APSshare
-#/APSshare/epics/synApps_6_1/support/xxx-R6-1/bin/linux-x86_64/xxx st.cmd
-

--- a/iocBoot/iocTomoScan_13BM_MCS/start_python.bat
+++ b/iocBoot/iocTomoScan_13BM_MCS/start_python.bat
@@ -1,0 +1,2 @@
+CALL  C:\ProgramData\Anaconda3\Scripts\activate.bat
+python -i start_tomoscan.py

--- a/iocBoot/iocTomoScan_13BM_MCS/start_tomoscan.py
+++ b/iocBoot/iocTomoScan_13BM_MCS/start_tomoscan.py
@@ -1,6 +1,9 @@
-# This script creates an object of type TomoScan13BM_MCS for doing tomography scans at APS beamline 13-BM-D
+# This script creates an object of type TomoScan13BM_PSO for doing tomography scans at APS beamline 13-BM-D
 # To run this script type the following:
 #     python -i start_tomoscan.py
 # The -i is needed to keep Python running, otherwise it will create the object and exit
 from tomoscan.tomoscan_13bm_mcs import TomoScan13BM_MCS
-ts = TomoScan13BM_MCS(["../../db/tomoScan_settings.req","../../db/tomoScan_13BM_settings.req"], {"$(P)":"TSTest:", "$(R)":"TS1:"})
+ts = TomoScan13BM_MCS(["../../db/tomoScan_settings.req",
+                       "../../db/tomoScan_13BM_MCS_settings.req", 
+                       "../../db/tomoScan_13BM_settings.req"], 
+                      {"$(P)":"13BMDPG2:", "$(R)":"TS:"})

--- a/iocBoot/iocTomoScan_13BM_MCS/start_tomoscan.py
+++ b/iocBoot/iocTomoScan_13BM_MCS/start_tomoscan.py
@@ -1,4 +1,4 @@
-# This script creates an object of type TomoScan13BM_PSO for doing tomography scans at APS beamline 13-BM-D
+# This script creates an object of type TomoScan13BM_MCS for doing tomography scans at APS beamline 13-BM-D
 # To run this script type the following:
 #     python -i start_tomoscan.py
 # The -i is needed to keep Python running, otherwise it will create the object and exit

--- a/iocBoot/iocTomoScan_13BM_MCS/tomoScan.substitutions
+++ b/iocBoot/iocTomoScan_13BM_MCS/tomoScan.substitutions
@@ -2,19 +2,19 @@ file "$(TOP)/db/tomoScan.template"
 {
 pattern
 {  P,      R,    CAMERA,    FILE_PLUGIN,   ROTATION,  SAMPLE_X,  SAMPLE_Y,      CLOSE_SHUTTER,        CLOSE_VALUE,        OPEN_SHUTTER,         OPEN_VALUE}
-{TSTest:, TS1:, 13BMDPG1:, 13BMDPG1:HDF1:, 13BMD:m38, 13BMD:m85, 13BMD:m90, 13BMA:CloseBMDShutter.PROC,    1,        13BMA:OpenBMDShutter.PROC,      1}
+{13BMDPG2:, TS:, 13BMDPG1:, 13BMDPG1:HDF1:, 13BMD:m38, 13BMD:m85, 13BMD:m90, 13BMA:CloseBMDShutter.PROC,    1,        13BMA:OpenBMDShutter.PROC,      1}
 }
 
 file "$(TOP)/db/tomoScan_13BM_MCS.template"
 {
 pattern
 {  P,      R,      MCS}
-{TSTest:, TS1: 13BMD:SIS1:}
+{13BMDPG2:, TS: 13BMD:SIS1:}
 }
 
 file "$(TOP)/db/tomoScan_13BM.template"
 {
 pattern
 {  P,      R,       BEAM_READY,      READY_VALUE,}
-{TSTest:, TS1:, 13BMA:mono_pid1Locked,     1,}
+{13BMDPG2:, TS:, 13BMA:mono_pid1Locked,     1,}
 }

--- a/tomoscan/tomoscan.py
+++ b/tomoscan/tomoscan.py
@@ -238,7 +238,7 @@ class TomoScan():
         """Copies the FilePath PV to file plugin FilePath"""
 
         value = self.epics_pvs['FilePath'].get(as_string=True)
-        self.epics_pvs['FPFilePath'].put(value)
+        self.epics_pvs['FPFilePath'].put(value, wait=True)
 
     def copy_file_path_exists(self):
         """Copies the file plugin FilePathExists_RBV PV to FilePathExists"""
@@ -546,8 +546,8 @@ class TomoScan():
         # Set the exposure time
         self.set_exposure_time()
         # Set the file path, file name and file number
-        self.epics_pvs['FPFilePath'].put(self.epics_pvs['FilePath'].value)
-        self.epics_pvs['FPFileName'].put(self.epics_pvs['FileName'].value)
+        self.epics_pvs['FPFilePath'].put(self.epics_pvs['FilePath'].value, wait=True)
+        self.epics_pvs['FPFileName'].put(self.epics_pvs['FileName'].value, wait=True) 
 
         # Copy the current values of scan parameters into class variables
         self.exposure_time        = self.epics_pvs['ExposureTime'].value
@@ -839,9 +839,9 @@ class TomoScan():
         # We need to use the actual exposure time that the camera is using, not the requested time
         exposure = self.epics_pvs['CamAcquireTimeRBV'].value
         # Add some extra time to exposure time for margin.
-        # Adding 0.5% to the exposure time, and at least 1 ms seems to work for FLIR cameras
+        # Adding 1% to the exposure time, and at least 1 ms seems to work for FLIR cameras
         # This is empirical and should be made camera dependent
-        frame_time = exposure * 1.005
+        frame_time = exposure * 1.010
 
         # If the time is less than the readout time then use the readout time plus 1 ms.
         if frame_time < readout:


### PR DESCRIPTION
Most of these changes only affect tomoscan_13BM_MCS.  But there are 2 changes to tomoscan.py:

- Increase the time padding in compute_frame_time from 0.5% to 1.0%.  This was needed for some exposure times.
- Add wait=True when writing the FileName and FilePath in begin_scan().  I was having trouble with an external script that wrote the FileName PV and then immediately started a scan.  It would still be using the previous FileName.  Using wait=True seems to fix this problem.