### PR TITLE
add_theta() now handles missing projections

### DIFF
--- a/iocBoot/iocTomoScanStream_2BMB/st.cmd
+++ b/iocBoot/iocTomoScanStream_2BMB/st.cmd
@@ -10,7 +10,7 @@ dbLoadDatabase "../../dbd/tomoScanApp.dbd"
 tomoScanApp_registerRecordDeviceDriver pdbbase
 
 # Connect to the Aerotech controller
-drvAsynIPPortConfigure("PSO_PORT", "164.54.113.74:8000", 0, 0, 0)
+drvAsynIPPortConfigure("PSO_PORT", "164.54.113.74:8001", 0, 0, 0)
 asynOctetSetInputEos(PSO_PORT, 0, "\n")
 asynOctetSetOutputEos(PSO_PORT, 0, "\n")
 asynSetTraceIOMask(PSO_PORT, 0, ESCAPE)

--- a/tomoscan/tomoscan_2bm.py
+++ b/tomoscan/tomoscan_2bm.py
@@ -8,6 +8,7 @@
 import time
 import os
 import h5py 
+import numpy as np
 
 from tomoscan import data_management as dm
 from tomoscan import TomoScanPSO
@@ -257,27 +258,40 @@ class TomoScan2BM(TomoScanPSO):
             try:
                 f = h5py.File(full_file_name, "a")
                 with f:
-                    try:
+                    # try:
+                    if (0==0):
                         if self.theta is not None:
+                            # theta_ds = f.create_dataset('/exchange/theta', (len(self.theta),))
+                            # theta_ds[:] = self.theta[:]
+
                             unique_ids = f['/defaults/NDArrayUniqueId']
-                            shift_start = int(self.num_dark_fields > 0) and (self.dark_field_mode in ('Start', 'Both'))+ \
-                                          int(self.num_flat_fields > 0) and (self.flat_field_mode in ('Start', 'Both'))                            
+                            shift_start = int(self.num_dark_fields > 0 and (self.dark_field_mode in ('Start', 'Both')))+ \
+                                          int(self.num_flat_fields > 0 and (self.flat_field_mode in ('Start', 'Both')))                            
                             # find beginnings of sorted subarrays
                             # for [1,2,1,3,1,2,3,4,1,2] returns 0,2,4,8
                             ids_list = [0,*np.where(unique_ids[1:]-unique_ids[:-1]<0)[0]+1]                            
                             # extract projection ids
-                            if(len(ids_list)==1):
-                                proj_ids = ids_list
+                            if(len(ids_list[shift_start:])==1):
+                                proj_ids = unique_ids[ids_list[shift_start]:]
                             else:
                                 proj_ids = unique_ids[ids_list[shift_start]:ids_list[shift_start+1]]
-                            
+                            # subtract first id
+                            proj_ids -= proj_ids[0]
+                            # create theta dataset in hdf5 file
                             theta_ds = f.create_dataset('/exchange/theta', (len(proj_ids),))
-                            theta_ds[:] = self.theta[proj_ids-1]
-                            if(len(proj_ids)!=len(self.theta)):
+                            theta_ds[:] = self.theta[proj_ids]
+                            print(proj_ids)
+
+                            if(len(proj_ids) != len(self.theta)):
                                 log.warning('There are %d missing frames',len(self.theta)-len(proj_ids))
-                    except:
-                        log.error('Add theta: Failed accessing: %s', full_file_name)
-                        traceback.print_exc(file=sys.stdout)
+                                missed_ids = [ele for ele in range(len(self.theta)) if ele not in proj_ids]
+                                missed_theta = self.theta[missed_ids]
+                                log.warning(f'Missed ids: {list(missed_ids)}')
+                                log.warning(f'Missed theta: {list(missed_theta)}')
+                                
+                    # except:
+                    #     log.error('Add theta: Failed accessing: %s', full_file_name)
+                    #     traceback.print_exc(file=sys.stdout)
             except OSError:
                 log.error('Add theta aborted: %s not closed', full_file_name)
         else:


### PR DESCRIPTION
This adds a theta array in the hdf file that is correct even when there are dropped projections. This is not that critical for equally spaced angles but it is for multiple rotation interlaced. This address #112. 
Changes only affect 2-BM implementation. It is fully tested at 2-BM-B. I will keep this open for a couple of days till is fully tested at 2-BM-A