### PR TITLE
Fix bug with the rotation motor speed calculation

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -21,14 +21,14 @@
 
 TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
 
-SUPPORT=/home/beams/FUELSPRAY/epics/synApps/support
+SUPPORT=/local/usertxm/epics/synApps/support
 
-BUSY=$(SUPPORT)/busy-1-7-3
-AUTOSAVE=$(SUPPORT)/autosave-5-10-2
-ASYN=$(SUPPORT)/asyn-4-41
+BUSY=$(SUPPORT)/busy-R1-7-2
+AUTOSAVE=$(SUPPORT)/autosave-R5-10
+ASYN=$(SUPPORT)/asyn-R4-37
 
 # EPICS_BASE usually appears last so other apps can override stuff:
-EPICS_BASE=/APSshare/epics/base-3.15.6
+EPICS_BASE=/local/usertxm/epics/epics-base
 
 # Set RULES here if you want to take build rules from somewhere
 # other than EPICS_BASE:

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -21,14 +21,14 @@
 
 TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
 
-SUPPORT=/local/usertxm/epics/synApps/support
+SUPPORT=/home/beams/FUELSPRAY/epics/synApps/support
 
-BUSY=$(SUPPORT)/busy-R1-7-2
-AUTOSAVE=$(SUPPORT)/autosave-R5-10
-ASYN=$(SUPPORT)/asyn-R4-37
+BUSY=$(SUPPORT)/busy-1-7-3
+AUTOSAVE=$(SUPPORT)/autosave-5-10-2
+ASYN=$(SUPPORT)/asyn-4-41
 
 # EPICS_BASE usually appears last so other apps can override stuff:
-EPICS_BASE=/local/usertxm/epics/epics-base
+EPICS_BASE=/APSshare/epics/base-3.15.6
 
 # Set RULES here if you want to take build rules from somewhere
 # other than EPICS_BASE:

--- a/docs/source/tomoScanApp.rst
+++ b/docs/source/tomoScanApp.rst
@@ -1247,10 +1247,13 @@ Interlaced scan
     - Flag controlling whether the scan is regualr or interlaced. Choices are 'No' and 'Yes'. When "No" the angles are equally spaced using the Start angle, # of angles and Angle step parameters. When 'Yes' the list of angles is read from a file.
   * - $(P)$(R)InterlacedFileName
     - waveform
-    - The file name containing the list of interalced angles.
-  * - $(P)$(R)InterlacedRetakeFlat
-    - busy,
-    - Interlaced retake flat. Choices are 'Done' and 'Capture'. When 'Capture' a new set of flat field images will be collected.
+    - The file name containing the list of interalced angles in npy format.
+  * - $(P)$(R)InterlacedFileName
+    - waveform
+    - Interlaced file name containing the numpy list of angles to collect in interlaced mode.
+  * - $(P)$(R)StabilizationTime
+    - ao
+    - Settling time after the rotary stage motion is completed (used only in step scans).
 
 tomoScan_32ID_settings.req
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tomoscan/tomoscan_pso.py
+++ b/tomoscan/tomoscan_pso.py
@@ -91,9 +91,6 @@ class TomoScanPSO(TomoScan):
         # Call the base class method
         super().begin_scan()
  
-        # Compute the time for each frame
-        time_per_angle = self.compute_frame_time()
-        self.motor_speed = np.abs(self.rotation_step) / time_per_angle
         time.sleep(0.1)
 
         # Program the stage driver to provide PSO pulses
@@ -276,10 +273,7 @@ class TomoScanPSO(TomoScan):
         Assign the fly scan angular position to theta[]
         '''
         overall_sense, user_direction = self._compute_senses()
-        # Get the distance needed for acceleration = 1/2 a t^2 = 1/2 * v * t
-        motor_accl_time = float(self.epics_pvs['RotationAccelTime'].get()) # Acceleration time in s
-        accel_dist = motor_accl_time / 2.0 * float(self.motor_speed) 
-
+        
         # Compute the actual delta to keep each interval an integer number of encoder counts
         encoder_multiply = float(self.epics_pvs['PSOCountsPerRotation'].get()) / 360.
         raw_delta_encoder_counts = self.rotation_step * encoder_multiply
@@ -292,6 +286,13 @@ class TomoScanPSO(TomoScan):
         # Change the rotation step Python variable and PV
         self.rotation_step = delta_encoder_counts / encoder_multiply
         self.epics_pvs['RotationStep'].put(self.rotation_step)
+                
+        # Compute the time for each frame
+        time_per_angle = self.compute_frame_time()
+        self.motor_speed = np.abs(self.rotation_step) / time_per_angle
+        # Get the distance needed for acceleration = 1/2 a t^2 = 1/2 * v * t
+        motor_accl_time = float(self.epics_pvs['RotationAccelTime'].get()) # Acceleration time in s
+        accel_dist = motor_accl_time / 2.0 * float(self.motor_speed) 
           
         # Make taxi distance an integer number of measurement deltas >= accel distance
         # Add 1/2 of a delta to ensure that we are really up to speed.


### PR DESCRIPTION
In the initial version self.motor_speed is calculated before updating the rotation_step size according to the number of pulses per rotation. For cameras with low pulse counts per rotation, e.g. PG camera at 32-ID with 94400 pulses, this gives significant difference in motor speeds and therefore yields a lot of missing frames.
In this PR, I put calculation of the motor_speed after recomputing the rotation_step size according to the number of pulses per rotation.

