### PR TITLE
Add return to home, abort on file write errors, bug fix for negative rotations

### DIFF
--- a/tomoScanApp/Db/tomoScan.template
+++ b/tomoScanApp/Db/tomoScan.template
@@ -90,10 +90,14 @@ record(longout, "$(P)$(R)NumAngles")
 {
 }
 
-record(bo, "$(P)$(R)ReturnRotation")
+record(mbbo, "$(P)$(R)ReturnRotation")
 {
-   field(ZNAM, "No")
-   field(ONAM, "Yes")
+   field(ZRVL, "0")
+   field(ZRST, "No")
+   field(ONVL, "1")
+   field(ONST, "Yes")
+   field(TWVL, "2")
+   field(TWST, "Home")
 }
 
 ####################

--- a/tomoscan/tomoscan.py
+++ b/tomoscan/tomoscan.py
@@ -308,8 +308,9 @@ class TomoScan():
             self.run_fly_scan()
         elif (pvname.find('AbortScan') != -1) and (value == 1):
             self.abort_scan()
-        elif (pvname.find('FPWriteStatus') != -1) and (value == 1):
+        elif (pvname.find('WriteStatus') != -1) and (value == 1):
             self.abort_scan()
+
 
     def show_pvs(self):
         """Prints the current values of all EPICS PVs in use.
@@ -667,6 +668,8 @@ class TomoScan():
 
         if self.return_rotation == 'Yes':
             self.epics_pvs['Rotation'].put(self.rotation_start)
+        elif self.return_rotation == "Home":
+            self.epics_pvs['RotationHomF'].put(1)
         log.info('Scan complete')
         self.epics_pvs['ScanStatus'].put('Scan complete')
         self.epics_pvs['StartScan'].put(0)

--- a/tomoscan/tomoscan.py
+++ b/tomoscan/tomoscan.py
@@ -171,6 +171,7 @@ class TomoScan():
         self.control_pvs['FPAutoSave']        = PV(prefix + 'AutoSave')
         self.control_pvs['FPEnableCallbacks'] = PV(prefix + 'EnableCallbacks')
         self.control_pvs['FPXMLFileName']     = PV(prefix + 'XMLFileName')
+        self.control_pvs['FPWriteStatus']     = PV(prefix + 'WriteStatus')
 
         # Set some initial PV values
         file_path = self.config_pvs['FilePath'].get(as_string=True)
@@ -227,7 +228,7 @@ class TomoScan():
 
         # Configure callbacks on a few PVs
         for epics_pv in ('MoveSampleIn', 'MoveSampleOut', 'StartScan', 'AbortScan', 'ExposureTime',
-                         'FilePath', 'FPFilePathExists'):
+                         'FilePath', 'FPFilePathExists', 'FPWriteStatus'):
             self.epics_pvs[epics_pv].add_callback(self.pv_callback)
         for epics_pv in ('MoveSampleIn', 'MoveSampleOut', 'StartScan', 'AbortScan'):
             self.epics_pvs[epics_pv].put(0)
@@ -283,6 +284,8 @@ class TomoScan():
         - ``FilePath`` : Runs ``copy_file_path`` in a new thread.
 
         - ``FPFilePathExists`` : Runs ``copy_file_path_exists`` in a new thread.
+
+        - ``FPWriteStatus``: Runs ``abort_scan()``
         """
 
         log.debug('pv_callback pvName=%s, value=%s, char_value=%s', pvname, value, char_value)
@@ -304,6 +307,8 @@ class TomoScan():
         elif (pvname.find('StartScan') != -1) and (value == 1):
             self.run_fly_scan()
         elif (pvname.find('AbortScan') != -1) and (value == 1):
+            self.abort_scan()
+        elif (pvname.find('FPWriteStatus') != -1) and (value == 1):
             self.abort_scan()
 
     def show_pvs(self):
@@ -479,9 +484,12 @@ class TomoScan():
         config = {}
         for key in self.config_pvs:
             config[key] = self.config_pvs[key].get(as_string=True)
-        out_file = open(file_name, 'w')
-        json.dump(config, out_file, indent=2)
-        out_file.close()
+        try:
+            out_file = open(file_name, 'w')
+            json.dump(config, out_file, indent=2)
+            out_file.close()
+        except (PermissionError, FileNotFoundError) as error:
+            self.epics_pvs['ScanStatus'].put('Error writing configuration')
 
     def load_configuration(self, file_name):
         """Loads a configuration from a file into the EPICS PVs.

--- a/tomoscan/tomoscan_pso.py
+++ b/tomoscan/tomoscan_pso.py
@@ -194,6 +194,8 @@ class TomoScanPSO(TomoScan):
         '''
         self.epics_pvs['ScanStatus'].put('Programming PSO')
         overall_sense, user_direction = self._compute_senses()
+        log.info(f'Overall sense = {overall_sense}')
+        log.info(f'User direction = {user_direction}')
         pso_command = self.epics_pvs['PSOCommand.BOUT']
         pso_model = self.epics_pvs['PSOControllerModel'].get(as_string=True)
         pso_axis = self.epics_pvs['PSOAxisName'].get(as_string=True)
@@ -260,12 +262,13 @@ class TomoScanPSO(TomoScan):
         user direction, overall sense.
         '''
         # Encoder direction compared to dial coordinates
-        encoder_dir = 1 if self.epics_pvs['PSOEncoderCountsPerStep'].get() > 0 else -1
+        encoder_dir = 1 if self.epics_pvs['PSOCountsPerRotation'].get() > 0 else -1
         # Get motor direction (dial vs. user); convert (0,1) = (pos, neg) to (1, -1)
         motor_dir = 1 if self.epics_pvs['RotationDirection'].get() == 0 else -1
         # Figure out whether motion is in positive or negative direction in user coordinates
         user_direction = 1 if self.rotation_stop > self.rotation_start else -1
         # Figure out overall sense: +1 if motion in + encoder direction, -1 otherwise
+        log.debug((encoder_dir, motor_dir, user_direction))
         return user_direction * motor_dir * encoder_dir, user_direction
         
     def compute_positions_PSO(self):
@@ -309,7 +312,7 @@ class TomoScanPSO(TomoScan):
         
         #Where will the last point actually be?
         self.rotation_stop = (self.rotation_start 
-                                + (self.num_angles - 1) * self.rotation_step * user_direction)
+                                + (self.num_angles - 1) * self.rotation_step)
         self.epics_pvs['PSOEndTaxi'].put(self.rotation_stop + taxi_dist * user_direction)
         
         # Assign the fly scan angular position to theta[]


### PR DESCRIPTION
This commit adds three things:
* In tomoscan.py, adds a "Home" option to ReturnRotation.  This is useful for helical scans, since one may have several revolutions in such scans and it is often needless to return all the way to the start position.
* In tomoscay.py, add monitoring of the WriteStatus PV of the file writer.  If this flags a file write error, abort the scan, since there is little reason to continue a scan if the data aren't being saved.
* In tomoscan_pso.py, I found bugs in how negative rotations were handled as I was testing the rotation return to home.  These are now fixed and tested at 7-BM, but probably should be tested at other beamlines to ensure the fix is correct.