### PR TITLE
added log messages for camera and hdfplugin prefix change; 

### DIFF
--- a/tomoscan/tomoscan_2bm.py
+++ b/tomoscan/tomoscan_2bm.py
@@ -106,7 +106,7 @@ class TomoScan2BM(TomoScanHelical):
             prefix = self.pv_prefixes['MctOptics']
             self.epics_pvs['CameraSelect'] = PV(prefix + 'CameraSelect')
             camera_select = self.epics_pvs['CameraSelect'].value
-            log.info('changing camera prefix to: camera%s', camera_select)
+            log.info('changing camera prefix to camera %s', camera_select)
 
             if camera_select == None:
                 log.error('mctOptics is down. Please start mctOptics first')
@@ -125,9 +125,9 @@ class TomoScan2BM(TomoScanHelical):
 
 
             self.epics_pvs['CameraPVPrefix'].put(camera_prefix)
-            print(camera_prefix)
+            log.info(camera_prefix)
             self.epics_pvs['FilePluginPVPrefix'].put(hdf_prefix)
-            print(hdf_prefix)
+            log.info(hdf_prefix)
 
             # self.epics_pvs['CameraPVPrefix'] = PV(prefix + 'Camera0PVPrefix')
             # self.epics_pvs['Camera1'] = PV(prefix + 'Camera1PVPrefix')


### PR DESCRIPTION
fully tested at 2-BM where is now possible to swap detector using the motorized Optique Peter camera selector. The camera change currently takes ~ 40s. After the new camera is in place, tomoScan automatically runs using the new camera. [mctOptics](https://mctoptics.readthedocs.io/en/latest/about.html) automatically changes rotation axis roll and pitch to keep alignment
