### PR TITLE
Move ImagePixelSize initialization for tomoscan_2bm.py

### DIFF
--- a/tomoscan/tomoscan_2bm.py
+++ b/tomoscan/tomoscan_2bm.py
@@ -48,6 +48,9 @@ class TomoScan2BM(TomoScanHelical):
     def __init__(self, pv_files, macros):
         super().__init__(pv_files, macros)
 
+        prefix = self.pv_prefixes['MctOptics']
+        self.epics_pvs['ImagePixelSize']        = PV(prefix + 'ImagePixelSize')
+
         # set TomoScan xml files
         self.epics_pvs['CamNDAttributesFile'].put('TomoScanDetectorAttributes.xml')
         self.epics_pvs['FPXMLFileName'].put('TomoScanLayout.xml')

--- a/tomoscan/tomoscan_helical.py
+++ b/tomoscan/tomoscan_helical.py
@@ -42,9 +42,6 @@ class TomoScanHelical(TomoScanPSO):
         self.epics_pvs['SampleYHLM']            = PV(sample_y_pv_name + '.HLM')
         self.epics_pvs['SampleYLLM']            = PV(sample_y_pv_name + '.LLM')
 
-        prefix = self.pv_prefixes['MctOptics']
-        self.epics_pvs['ImagePixelSize']        = PV(prefix + 'ImagePixelSize')
-
 
     def begin_scan(self):
         """Performs the operations needed at the very start of a scan.


### PR DESCRIPTION
This has been moved from tomoscan_helical.py.  It was causing errors for 7-BM, which does not have MctOptics.