### PR TITLE
Various improvements at 2-BM and 32-ID. Fix for all beamlines of the backward scan issue reported at #160

### DIFF
--- a/iocBoot/iocTomoScanStream_2BMB/tomoScanStream.substitutions
+++ b/iocBoot/iocTomoScanStream_2BMB/tomoScanStream.substitutions
@@ -25,6 +25,6 @@ file "$(TOP)/db/tomoScanStream.template"
 {
 pattern
 {  P,        R,           PVA_PLUGIN,     ROI_PLUGIN,     CB_PLUGIN,          PVA_STREAM,}
-{2bmb:, TomoScanStream:, 2bmbSP2:Pva1:,  2bmbSP2:ROI1:,  2bmbSP2:CB1:, 2bmb:TomoScanStream:,}
+{2bmb:, TomoScanStream:, 2bmbSP2:Pva1:,  2bmbSP2:ROI1:,  2bmbSP2:CB1:, 2bmb:TomoScanStream:}
 }
 

--- a/iocBoot/iocTomoScan_2BMA/tomoScan.substitutions
+++ b/iocBoot/iocTomoScan_2BMA/tomoScan.substitutions
@@ -17,6 +17,6 @@ pattern
 file "$(TOP)/db/tomoScan_2BM.template"
 {
 pattern
-{  P,      R,           BEAM_READY,     READY_VALUE,    CLOSE_FAST_SHUTTER,  CLOSE_FAST_VALUE,   OPEN_FAST_SHUTTER,  OPEN_FAST_VALUE,         SHUTTER_STATUS,}
-{2bma:, TomoScan:, ACIS:ShutterPermit,       1,             2bma:m23,               0,                 2bma:m23,              1,           PA:02BM:STA_A_FES_OPEN_PL,}
+{  P,      R,           BEAM_READY,     READY_VALUE,    CLOSE_FAST_SHUTTER,  CLOSE_FAST_VALUE,   OPEN_FAST_SHUTTER,  OPEN_FAST_VALUE,         SHUTTER_STATUS,         PVA_PLUGIN,     ROI_PLUGIN,     CB_PLUGIN}
+{2bma:, TomoScan:, ACIS:ShutterPermit,       1,             2bma:m23,               0,                 2bma:m23,              1,           PA:02BM:STA_A_FES_OPEN_PL, 2bmbSP2:Pva1:,  2bmbSP2:ROI1:,  2bmbSP2:CB1:}
 }

--- a/iocBoot/iocTomoScan_2BMB/tomoScan.substitutions
+++ b/iocBoot/iocTomoScan_2BMB/tomoScan.substitutions
@@ -23,6 +23,6 @@ pattern
 file "$(TOP)/db/tomoScan_2BM.template"
 {
 pattern
-{  P,      R,           BEAM_READY,     READY_VALUE,       CLOSE_FAST_SHUTTER,        CLOSE_FAST_VALUE,      OPEN_FAST_SHUTTER,       OPEN_FAST_VALUE,         SHUTTER_STATUS,}
-{2bmb:, TomoScan:, ACIS:ShutterPermit,       1,         2bma:B_shutter:close.VAL,            1,           2bma:B_shutter:open.VAL,           1,           PA:02BM:STA_A_FES_OPEN_PL,}
+{  P,      R,           BEAM_READY,     READY_VALUE,       CLOSE_FAST_SHUTTER,        CLOSE_FAST_VALUE,      OPEN_FAST_SHUTTER,       OPEN_FAST_VALUE,         SHUTTER_STATUS,         PVA_PLUGIN,     ROI_PLUGIN,     CB_PLUGIN}
+{2bmb:, TomoScan:, ACIS:ShutterPermit,       1,         2bma:B_shutter:close.VAL,            1,           2bma:B_shutter:open.VAL,           1,           PA:02BM:STA_A_FES_OPEN_PL,  2bmbSP2:Pva1:,  2bmbSP2:ROI1:,  2bmbSP2:CB1:}
 }

--- a/iocBoot/iocTomoScan_2BMB_STEP/st.cmd
+++ b/iocBoot/iocTomoScan_2BMB_STEP/st.cmd
@@ -1,7 +1,7 @@
 < envPaths
 
 epicsEnvSet("P", "2bmb:")
-epicsEnvSet("R", "TomoScan:")
+epicsEnvSet("R", "TomoScanStep:")
 
 ## Register all support components
 

--- a/iocBoot/iocTomoScan_2BMB_STEP/start_medm
+++ b/iocBoot/iocTomoScan_2BMB_STEP/start_medm
@@ -1,1 +1,1 @@
-medm -x -macro "P=2bmb:,R=TomoScan:,BEAMLINE=tomoScan_2BM" ../../tomoScanApp/op/adl/tomoScan.adl &
+medm -x -macro "P=2bmb:,R=TomoScanStep:,BEAMLINE=tomoScan_2BM" ../../tomoScanApp/op/adl/tomoScan.adl  &

--- a/iocBoot/iocTomoScan_2BMB_STEP/start_tomoscan.py
+++ b/iocBoot/iocTomoScan_2BMB_STEP/start_tomoscan.py
@@ -4,5 +4,6 @@
 # The -i is needed to keep Python running, otherwise it will create the object and exit
 from tomoscan.tomoscan_2bm_step import TomoScan2BMSTEP
 ts = TomoScan2BMSTEP(["../../db/tomoScan_settings.req",
+                  "../../db/tomoScan_step_settings.req",
                   "../../db/tomoScan_2BM_settings.req"], 
-                 {"$(P)":"2bmb:", "$(R)":"TomoScan:"})
+                 {"$(P)":"2bmb:", "$(R)":"TomoScanStep:"})

--- a/iocBoot/iocTomoScan_2BMB_STEP/tomoScan.substitutions
+++ b/iocBoot/iocTomoScan_2BMB_STEP/tomoScan.substitutions
@@ -1,13 +1,13 @@
 file "$(TOP)/db/tomoScan.template"
 {
 pattern
-{  P,      R,      CAMERA,    FILE_PLUGIN,   ROTATION,  SAMPLE_X,  SAMPLE_Y,      CLOSE_SHUTTER,        CLOSE_VALUE,        OPEN_SHUTTER,         OPEN_VALUE}
-{2bmb:, TomoScan:, 2bmbPG1:, 2bmbPG1:HDF1:,  2bmb:m100,  2bmb:m63,  2bmb:m25,  2bma:A_shutter:close.VAL,    1,        2bma:A_shutter:open.VAL,      1}
+{  P,        R,        CAMERA,    FILE_PLUGIN,    ROTATION,   SAMPLE_X,  SAMPLE_Y,      CLOSE_SHUTTER,        CLOSE_VALUE,        OPEN_SHUTTER,         OPEN_VALUE}
+{2bmb:, TomoScanStep:, 2bmbPG1:,  2bmbPG1:HDF1:,  2bmb:m100,  2bmb:m63,  2bmb:m25,  2bma:A_shutter:close.VAL,      1,        2bma:A_shutter:open.VAL,        1}
 }
 
 file "$(TOP)/db/tomoScan_2BM.template"
 {
 pattern
-{  P,      R,           BEAM_READY,     READY_VALUE,    CLOSE_FAST_SHUTTER,  CLOSE_FAST_VALUE,   OPEN_FAST_SHUTTER,  OPEN_FAST_VALUE,         SHUTTER_STATUS,}
-{2bmb:, TomoScan:, ACIS:ShutterPermit,       1,             2bmb:m77,               41,                2bmb:m77,             41,           PA:02BM:STA_A_FES_OPEN_PL,}
+{  P,        R,           BEAM_READY,      READY_VALUE,    CLOSE_FAST_SHUTTER,   CLOSE_FAST_VALUE,    OPEN_FAST_SHUTTER,   OPEN_FAST_VALUE,         SHUTTER_STATUS,}
+{2bmb:, TomoScanStep:, ACIS:ShutterPermit,       1,             2bmb:m77,               41,                2bmb:m77,             41,            PA:02BM:STA_A_FES_OPEN_PL,}
 }

--- a/iocBoot/iocTomoScan_2BMB_STEP/tomoScan.substitutions
+++ b/iocBoot/iocTomoScan_2BMB_STEP/tomoScan.substitutions
@@ -8,6 +8,6 @@ pattern
 file "$(TOP)/db/tomoScan_2BM.template"
 {
 pattern
-{  P,        R,           BEAM_READY,      READY_VALUE,    CLOSE_FAST_SHUTTER,   CLOSE_FAST_VALUE,    OPEN_FAST_SHUTTER,   OPEN_FAST_VALUE,         SHUTTER_STATUS,}
-{2bmb:, TomoScanStep:, ACIS:ShutterPermit,       1,             2bmb:m77,               41,                2bmb:m77,             41,            PA:02BM:STA_A_FES_OPEN_PL,}
+{  P,        R,           BEAM_READY,      READY_VALUE,    CLOSE_FAST_SHUTTER,   CLOSE_FAST_VALUE,    OPEN_FAST_SHUTTER,   OPEN_FAST_VALUE,         SHUTTER_STATUS,        PVA_PLUGIN,     ROI_PLUGIN,     CB_PLUGIN}
+{2bmb:, TomoScanStep:, ACIS:ShutterPermit,       1,             2bmb:m77,               41,                2bmb:m77,             41,            PA:02BM:STA_A_FES_OPEN_PL, 2bmbSP2:Pva1:,  2bmbSP2:ROI1:,  2bmbSP2:CB1:}
 }

--- a/tomoScanApp/Db/tomoScan_2BM.template
+++ b/tomoScanApp/Db/tomoScan_2BM.template
@@ -201,3 +201,31 @@ record(bo, "$(P)$(R)FlipStitch")
    field(ZNAM, "No")
    field(ONAM, "Yes")
 }
+
+
+######################
+# Pva Plugin PV Prefix
+######################
+
+record(stringout, "$(P)$(R)PvaPluginPVPrefix")
+{
+   field(VAL,  "$(PVA_PLUGIN)")
+}
+
+######################
+# Roi Plugin PV Prefix
+######################
+
+record(stringout, "$(P)$(R)RoiPluginPVPrefix")
+{
+   field(VAL,  "$(ROI_PLUGIN)")
+}
+
+#####################
+# Cb Plugin PV Prefix
+#####################
+
+record(stringout, "$(P)$(R)CbPluginPVPrefix")
+{
+   field(VAL,  "$(CB_PLUGIN)")
+}

--- a/tomoScanApp/Db/tomoScan_2BM_settings.req
+++ b/tomoScanApp/Db/tomoScan_2BM_settings.req
@@ -57,3 +57,22 @@ $(P)$(R)ShutterStatusPVName
 ################
 $(P)$(R)MctOpticsPVPrefix
 
+################
+# AD plugins
+################
+$(P)$(R)PvaPluginPVPrefix
+
+######################
+# Pva Plugin PV Prefix
+######################
+$(P)$(R)PvaPluginPVPrefix
+
+######################
+# Roi Plugin PV Prefix
+######################
+$(P)$(R)RoiPluginPVPrefix
+
+#####################
+# Cb Plugin PV Prefix
+#####################
+$(P)$(R)CbPluginPVPrefix

--- a/tomoScanApp/Db/tomoScan_32ID.template
+++ b/tomoScanApp/Db/tomoScan_32ID.template
@@ -162,10 +162,14 @@ record(stringout, "$(P)$(R)RemoteAnalysisDir")
    field(VAL,  "Unknown")
 }
 
-record(bo, "$(P)$(R)CopyToAnalysisDir")
+record(mbbo, "$(P)$(R)CopyToAnalysisDir")
 {
-   field(ZNAM, "No")
-   field(ONAM, "Yes")
+   field(ZRVL, "0")
+   field(ZRST, "None")
+   field(ONVL, "1")
+   field(ONST, "fdt")
+   field(TWVL, "2")
+   field(TWST, "scp")
 }
 
 ######################

--- a/tomoScanApp/op/adl/tomoScan_2BM_otherpvs.adl
+++ b/tomoScanApp/op/adl/tomoScan_2BM_otherpvs.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/home/beams/USER2BMB/epics/synApps/support/tomoscan/tomoScanApp/op/adl/tomoScan_2BM_otherpvs.adl"
+	name="/home/beams8/USER2BMB/epics/synApps/support/tomoscan/tomoScanApp/op/adl/tomoScan_2BM_otherpvs.adl"
 	version=030111
 }
 display {
 	object {
-		x=710
-		y=223
+		x=342
+		y=927
 		width=640
-		height=330
+		height=405
 	}
 	clr=14
 	bclr=4
@@ -317,145 +317,6 @@ text {
 text {
 	object {
 		x=10
-		y=255
-		width=130
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Scan type"
-	align="horiz. right"
-}
-menu {
-	object {
-		x=145
-		y=255
-		width=80
-		height=20
-	}
-	control {
-		chan="$(P)$(R)ScanType"
-		clr=14
-		bclr=51
-	}
-}
-menu {
-	object {
-		x=145
-		y=280
-		width=80
-		height=20
-	}
-	control {
-		chan="$(P)$(R)FlipStitch"
-		clr=14
-		bclr=51
-	}
-}
-text {
-	object {
-		x=10
-		y=280
-		width=130
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Flip&Stitch"
-	align="horiz. right"
-}
-text {
-	object {
-		x=160
-		y=305
-		width=90
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="PSO setup"
-	align="horiz. right"
-}
-"related display" {
-	object {
-		x=255
-		y=305
-		width=100
-		height=20
-	}
-	display[0] {
-		label="PSO setup"
-		name="tomoScan_pso.adl"
-		args="P=$(P), R=$(R)"
-	}
-	clr=14
-	bclr=51
-	label="PSO setup"
-}
-text {
-	object {
-		x=414
-		y=255
-		width=130
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Y Pixels Per 360 Deg"
-	align="horiz. right"
-}
-"text entry" {
-	object {
-		x=559
-		y=255
-		width=75
-		height=20
-	}
-	control {
-		chan="$(P)$(R)PixelsYPer360Deg"
-		clr=14
-		bclr=51
-	}
-	format="string"
-	limits {
-	}
-}
-text {
-	object {
-		x=413
-		y=280
-		width=130
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Helical Misalignment (mrad)"
-	align="horiz. right"
-}
-"text entry" {
-	object {
-		x=559
-		y=280
-		width=75
-		height=20
-	}
-	control {
-		chan="$(P)$(R)HelicalMisalignment"
-		clr=14
-		bclr=51
-	}
-	format="string"
-	limits {
-	}
-}
-text {
-	object {
-		x=10
 		y=220
 		width=240
 		height=20
@@ -482,29 +343,266 @@ text {
 	limits {
 	}
 }
+composite {
+	object {
+		x=10
+		y=330
+		width=630
+		height=70
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=10
+				y=330
+				width=130
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Scan type"
+			align="horiz. right"
+		}
+		menu {
+			object {
+				x=145
+				y=330
+				width=80
+				height=20
+			}
+			control {
+				chan="$(P)$(R)ScanType"
+				clr=14
+				bclr=51
+			}
+		}
+		menu {
+			object {
+				x=145
+				y=355
+				width=80
+				height=20
+			}
+			control {
+				chan="$(P)$(R)FlipStitch"
+				clr=14
+				bclr=51
+			}
+		}
+		text {
+			object {
+				x=10
+				y=355
+				width=130
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Flip&Stitch"
+			align="horiz. right"
+		}
+		text {
+			object {
+				x=160
+				y=380
+				width=90
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="PSO setup"
+			align="horiz. right"
+		}
+		"related display" {
+			object {
+				x=255
+				y=380
+				width=100
+				height=20
+			}
+			display[0] {
+				label="PSO setup"
+				name="tomoScan_pso.adl"
+				args="P=$(P), R=$(R)"
+			}
+			clr=14
+			bclr=51
+			label="PSO setup"
+		}
+		text {
+			object {
+				x=414
+				y=330
+				width=130
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Y Pixels Per 360 Deg"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=559
+				y=330
+				width=75
+				height=20
+			}
+			control {
+				chan="$(P)$(R)PixelsYPer360Deg"
+				clr=14
+				bclr=51
+			}
+			format="string"
+			limits {
+			}
+		}
+		text {
+			object {
+				x=413
+				y=355
+				width=130
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Helical Misalignment (mrad)"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=559
+				y=355
+				width=75
+				height=20
+			}
+			control {
+				chan="$(P)$(R)HelicalMisalignment"
+				clr=14
+				bclr=51
+			}
+			format="string"
+			limits {
+			}
+		}
+		text {
+			object {
+				x=365
+				y=380
+				width=150
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Program PSO"
+			align="horiz. right"
+		}
+		menu {
+			object {
+				x=520
+				y=380
+				width=120
+				height=20
+			}
+			control {
+				chan="$(P)$(R)ProgramPSO"
+				clr=14
+				bclr=51
+			}
+		}
+	}
+}
 text {
 	object {
-		x=365
-		y=305
-		width=150
+		x=10
+		y=245
+		width=240
 		height=20
 	}
 	"basic attribute" {
 		clr=14
 	}
-	textix="Program PSO"
+	textix="PVA plugin prefix"
 	align="horiz. right"
 }
-menu {
+"text entry" {
 	object {
-		x=520
-		y=305
-		width=120
+		x=255
+		y=245
+		width=380
 		height=20
 	}
 	control {
-		chan="$(P)$(R)ProgramPSO"
+		chan="$(P)$(R)PvaPluginPVPrefix"
 		clr=14
 		bclr=51
+	}
+	format="string"
+	limits {
+	}
+}
+text {
+	object {
+		x=10
+		y=270
+		width=240
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="ROI plugin prefix"
+	align="horiz. right"
+}
+"text entry" {
+	object {
+		x=255
+		y=270
+		width=380
+		height=20
+	}
+	control {
+		chan="$(P)$(R)RoiPluginPVPrefix"
+		clr=14
+		bclr=51
+	}
+	format="string"
+	limits {
+	}
+}
+text {
+	object {
+		x=10
+		y=295
+		width=240
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="CB plugin prefix"
+	align="horiz. right"
+}
+"text entry" {
+	object {
+		x=255
+		y=295
+		width=380
+		height=20
+	}
+	control {
+		chan="$(P)$(R)CbPluginPVPrefix"
+		clr=14
+		bclr=51
+	}
+	format="string"
+	limits {
 	}
 }

--- a/tomoScanApp/op/adl/tomoScan_32ID_main.adl
+++ b/tomoScanApp/op/adl/tomoScan_32ID_main.adl
@@ -1,6 +1,6 @@
 
 file {
-	name="/home/beams/USERTXM/epics/synApps/support/tomoscan/tomoScanApp/op/adl/tomoScan_32ID_main.adl"
+	name="/home/beams19/USERTXM/epics/synApps/support/tomoscan/tomoScanApp/op/adl/tomoScan_32ID_main.adl"
 	version=030111
 }
 display {
@@ -1365,9 +1365,9 @@ text {
 "text update" {
 	object {
 		x=160
-		y=500
+		y=505
 		width=530
-		height=20
+		height=15
 	}
 	monitor {
 		chan="32idcSP1:HDF1:FullFileName_RBV"

--- a/tomoscan/tomoscan.py
+++ b/tomoscan/tomoscan.py
@@ -906,6 +906,7 @@ class TomoScan():
                 'Mono12Packed': 30.0,
                 'Mono16': 30.0
             }
+            readout_margin = 1.2
             readout = readout_times[pixel_format]/1000.
         if camera_model == 'Q-12A180-Fm/CXP-6':
             pixel_format = self.epics_pvs['CamPixelFormat'].get(as_string=True) 

--- a/tomoscan/tomoscan.py
+++ b/tomoscan/tomoscan.py
@@ -936,6 +936,7 @@ class TomoScan():
         # If the time is less than the readout time then use the readout time plus 1 ms.
         if frame_time < readout:
             frame_time = readout + .001
+        self.readout_margin = readout_margin
         return frame_time
 
     def update_status(self, start_time):

--- a/tomoscan/tomoscan_2bm.py
+++ b/tomoscan/tomoscan_2bm.py
@@ -87,11 +87,17 @@ class TomoScan2BM(TomoScanHelical):
         if camera_select == None:
             log.error('mctOptics is down. Please start mctOptics first')
         else:
-            self.epics_pvs['Camera0'] = PV(prefix + 'Camera0PVPrefix')
-            self.epics_pvs['Camera1'] = PV(prefix + 'Camera1PVPrefix')
-            self.epics_pvs['CameraSelect'].add_callback(self.pv_callback_2bm)
+            self.epics_pvs['Camera0']     = PV(prefix + 'Camera0PVPrefix')
+            self.epics_pvs['Camera1']     = PV(prefix + 'Camera1PVPrefix')
             self.epics_pvs['FilePlugin0'] = PV(prefix + 'FilePlugin0PVPrefix')
             self.epics_pvs['FilePlugin1'] = PV(prefix + 'FilePlugin1PVPrefix')
+            self.epics_pvs['PvaPlugin1']  = PV(prefix + 'PvaPlugin1PVPrefix')
+            self.epics_pvs['RoiPlugin0']  = PV(prefix + 'RoiPlugin0PVPrefix')
+            self.epics_pvs['RoiPlugin1']  = PV(prefix + 'RoiPlugin1PVPrefix')
+            self.epics_pvs['CbPlugin0']   = PV(prefix + 'CbPlugin0PVPrefix')
+            self.epics_pvs['CbPlugin1']   = PV(prefix + 'CbPlugin1PVPrefix')
+
+            self.epics_pvs['CameraSelect'].add_callback(self.pv_callback_2bm)
 
     def pv_callback_2bm(self, pvname=None, value=None, char_value=None, **kw):
         """Callback function that is called by pyEpics when certain EPICS PVs are changed
@@ -121,26 +127,40 @@ class TomoScan2BM(TomoScanHelical):
             if camera_select == None:
                 log.error('mctOptics is down. Please start mctOptics first')
             else:
-                self.epics_pvs['Camera0'] = PV(prefix + 'Camera0PVPrefix')
-                self.epics_pvs['Camera1'] = PV(prefix + 'Camera1PVPrefix')
+                self.epics_pvs['Camera0']     = PV(prefix + 'Camera0PVPrefix')
+                self.epics_pvs['Camera1']     = PV(prefix + 'Camera1PVPrefix')
                 self.epics_pvs['FilePlugin0'] = PV(prefix + 'FilePlugin0PVPrefix')
                 self.epics_pvs['FilePlugin1'] = PV(prefix + 'FilePlugin1PVPrefix')
+                self.epics_pvs['PvaPlugin0']  = PV(prefix + 'PvaPlugin0PVPrefix')
+                self.epics_pvs['PvaPlugin1']  = PV(prefix + 'PvaPlugin1PVPrefix')
+                self.epics_pvs['RoiPlugin0']  = PV(prefix + 'RoiPlugin0PVPrefix')
+                self.epics_pvs['RoiPlugin1']  = PV(prefix + 'RoiPlugin1PVPrefix')
+                self.epics_pvs['CbPlugin0']   = PV(prefix + 'CbPlugin0PVPrefix')
+                self.epics_pvs['CbPlugin1']   = PV(prefix + 'CbPlugin1PVPrefix')
 
             if camera_select == 0:
                  camera_prefix = self.epics_pvs['Camera0'].get(as_string=True)
                  hdf_prefix    = self.epics_pvs['FilePlugin0'].get(as_string=True)
+                 pva_prefix    = self.epics_pvs['PvaPlugin0'].get(as_string=True)
+                 roi_prefix    = self.epics_pvs['RoiPlugin0'].get(as_string=True)
+                 cb_prefix     = self.epics_pvs['CbPlugin0'].get(as_string=True)
             else:
                  camera_prefix = self.epics_pvs['Camera1'].get(as_string=True)
                  hdf_prefix    = self.epics_pvs['FilePlugin1'].get(as_string=True)
-
+                 pva_prefix    = self.epics_pvs['PvaPlugin1'].get(as_string=True)
+                 roi_prefix    = self.epics_pvs['RoiPlugin1'].get(as_string=True)
+                 cb_prefix     = self.epics_pvs['CbPlugin1'].get(as_string=True)
 
             self.epics_pvs['CameraPVPrefix'].put(camera_prefix)
             log.info(camera_prefix)
             self.epics_pvs['FilePluginPVPrefix'].put(hdf_prefix)
             log.info(hdf_prefix)
-
-            # self.epics_pvs['CameraPVPrefix'] = PV(prefix + 'Camera0PVPrefix')
-            # self.epics_pvs['Camera1'] = PV(prefix + 'Camera1PVPrefix')
+            self.epics_pvs['PvaPluginPVPrefix'].put(pva_prefix)
+            log.info(pva_prefix)
+            self.epics_pvs['RoiPluginPVPrefix'].put(roi_prefix)
+            log.info(roi_prefix)
+            self.epics_pvs['CbPluginPVPrefix'].put(cb_prefix)
+            log.info(cb_prefix)
 
             self.pv_prefixes['FilePlugin'] = hdf_prefix
             # need to update TomoScan PV Prefix to the new camera / hdf plugin
@@ -213,7 +233,37 @@ class TomoScan2BM(TomoScanHelical):
             self.control_pvs['FPFileWriteMode'].put('Stream')
             self.control_pvs['FPEnableCallbacks'].put('Enable')
 
-            self.epics_pvs['FPEnableCallbacks'].put('Enable')  
+            prefix = pva_prefix
+            self.control_pvs['PVANDArrayPort']     = PV(prefix + 'NDArrayPort')                
+            self.control_pvs['PVAEnableCallbacks'] = PV(prefix + 'EnableCallbacks')        
+            # Set some initial PV values
+            self.control_pvs['PVANDArrayPort'].put('OVER1')
+            self.control_pvs['PVAEnableCallbacks'].put('Enable')
+
+            prefix = roi_prefix
+            self.control_pvs['ROINDArrayPort']     = PV(prefix + 'NDArrayPort')        
+            self.control_pvs['ROIScale']           = PV(prefix + 'Scale')        
+            self.control_pvs['ROIBinX']            = PV(prefix + 'BinX')        
+            self.control_pvs['ROIBinY']            = PV(prefix + 'BinY')
+            self.control_pvs['ROIEnableCallbacks'] = PV(prefix + 'EnableCallbacks')
+            # Set some initial PV values
+            self.control_pvs['ROIEnableCallbacks'].put('Disable')
+
+            prefix = cb_prefix
+            self.control_pvs['CBPortNameRBV']      = PV(prefix + 'PortName_RBV')                    
+            self.control_pvs['CBNDArrayPort']      = PV(prefix + 'NDArrayPort')        
+            self.control_pvs['CBPreCount']         = PV(prefix + 'PreCount')
+            self.control_pvs['CBPostCount']        = PV(prefix + 'PostCount')
+            self.control_pvs['CBCapture']          = PV(prefix + 'Capture')            
+            self.control_pvs['CBCaptureRBV']       = PV(prefix + 'Capture_RBV')
+            self.control_pvs['CBTrigger']          = PV(prefix + 'Trigger')
+            self.control_pvs['CBTriggerRBV']       = PV(prefix + 'Trigger_RBV')
+            self.control_pvs['CBCurrentQtyRBV']    = PV(prefix + 'CurrentQty_RBV')            
+            self.control_pvs['CBEnableCallbacks']  = PV(prefix + 'EnableCallbacks')
+            self.control_pvs['CBStatusMessage']    = PV(prefix + 'StatusMessage')
+            # Set some initial PV values
+            self.control_pvs['CBEnableCallbacks'].put('Disable')
+
 
             self.epics_pvs = {**self.config_pvs, **self.control_pvs}
             # Wait 1 second for all PVs to connect

--- a/tomoscan/tomoscan_2bm.py
+++ b/tomoscan/tomoscan_2bm.py
@@ -596,21 +596,6 @@ class TomoScan2BM(TomoScanHelical):
                         # create theta dataset in hdf5 file
                         if len(proj_ids) > 0:
                             theta_ds = f.create_dataset('/exchange/theta', (len(proj_ids),))
-                            
-                                
-                                
-                            #################TODO    
-                            if self.theta[1]-self.theta[0]<0:
-                                log.warning(f"the rotary stage at 2-bm is strange. To have the same reconstruction results for \
-                                    0..180 and 180-0 (both include 0 and 180) theta should be modified as follows theta+=0.8*rotation_step). \
-                                        This needs to be checked for other stages.")        
-                            self.theta+=0.8*self.rotation_step
-                            log.warning(f"new theta: {self.theta}")                            
-                            
-                            
-                            
-                            
-                            
                             theta_ds[:] = self.theta[proj_ids - proj_ids[0]]
 
                         # warnings that data is missing

--- a/tomoscan/tomoscan_2bm_step.py
+++ b/tomoscan/tomoscan_2bm_step.py
@@ -153,7 +153,7 @@ class TomoScan2BMSTEP(TomoScanSTEP):
         else: # set camera to internal triggering
             # These are just in case the scan aborted with the camera in another state 
             camera_model = self.epics_pvs['CamModel'].get(as_string=True)
-            if(camera_model=='Oryx ORX-10G-51S5M'):# 2bma            
+            if(camera_model=='Oryx ORX-10G-51S5M' or camera_model=='Oryx ORX-10G-310S9M'):
                 self.epics_pvs['CamTriggerMode'].put('Off', wait=True)   # VN: For FLIR we first switch to Off and then change overlap. any reason of that?                                                 
                 self.epics_pvs['CamTriggerSource'].put('Line2', wait=True)
             elif(camera_model=='Grasshopper3 GS3-U3-23S6M'):# 2bmb            

--- a/tomoscan/tomoscan_2bm_step.py
+++ b/tomoscan/tomoscan_2bm_step.py
@@ -48,6 +48,14 @@ class TomoScan2BMSTEP(TomoScanSTEP):
         # Disable over writing warning
         self.epics_pvs['OverwriteWarning'].put('Yes')
 
+        # Set AD plugins            
+        self.epics_pvs['PVANDArrayPort'].put('OVER1')
+        self.epics_pvs['PVAEnableCallbacks'].put('Enable')
+        self.epics_pvs['ROIEnableCallbacks'].put('Disable')
+        self.epics_pvs['CBEnableCallbacks'].put('Disable')
+        self.epics_pvs['FPEnableCallbacks'].put('Enable')  
+
+
         log.setup_custom_logger("./tomoscan.log")
 
     def open_frontend_shutter(self):

--- a/tomoscan/tomoscan_32id_step.py
+++ b/tomoscan/tomoscan_32id_step.py
@@ -60,6 +60,8 @@ class TomoScan32IDSTEP(TomoScanSTEP):
         self.epics_pvs['TXMMoveAllOut'] = PV(txmoptics_prefix+'MoveAllOut')
         self.epics_pvs['TXMMoveAllIn'] = PV(txmoptics_prefix+'MoveAllIn')  
 
+        self.epics_pvs['SampleXSet'] = PV(self.control_pvs['SampleX'].pvname + '.SET')
+        self.epics_pvs['SampleYSet'] = PV(self.control_pvs['SampleY'].pvname + '.SET')
         # energy scan
         self.epics_pvs['EnergySet'].put(0)
         self.epics_pvs['EnergySet'].add_callback(self.pv_callback_32id)
@@ -246,6 +248,13 @@ class TomoScan32IDSTEP(TomoScanSTEP):
         - Turns on data capture.
         """
         log.info('begin scan')
+        self.epics_pvs['SampleXSet'].put(1, wait=True)
+        self.epics_pvs['SampleYSet'].put(1, wait=True)
+        self.epics_pvs['SampleX'].put(0, wait=True)
+        self.epics_pvs['SampleY'].put(0, wait=True)
+        self.epics_pvs['SampleXSet'].put(0, wait=True)
+        self.epics_pvs['SampleYSet'].put(0, wait=True)
+        
 
         # Set data directory
         file_path = self.epics_pvs['DetectorTopDir'].get(as_string=True) + self.epics_pvs['ExperimentYearMonth'].get(as_string=True) + os.path.sep + self.epics_pvs['UserLastName'].get(as_string=True) + os.path.sep

--- a/tomoscan/tomoscan_helical.py
+++ b/tomoscan/tomoscan_helical.py
@@ -99,7 +99,7 @@ class TomoScanHelical(TomoScanPSO):
         self.epics_pvs['Rotation'].put(self.epics_pvs['PSOEndTaxi'].get())
         time_per_angle = self.compute_frame_time()
         collection_time = self.num_angles * time_per_angle
-        self.wait_camera_done(collection_time + 30.)
+        self.wait_camera_done(collection_time + 5.)
         
 
     def abort_scan(self):

--- a/tomoscan/tomoscan_pso.py
+++ b/tomoscan/tomoscan_pso.py
@@ -330,7 +330,3 @@ class TomoScanPSO(TomoScan):
         # Assign the fly scan angular position to theta[]
         self.theta = self.rotation_start + np.arange(self.num_angles) * self.rotation_step
         
-        # When doing backwards we need to re-label the angle location so the exposure occurs at the same location
-        # if user_direction<0:
-            # self.theta+=self.rotation_step
-        

--- a/tomoscan/tomoscan_pso.py
+++ b/tomoscan/tomoscan_pso.py
@@ -243,8 +243,8 @@ class TomoScanPSO(TomoScan):
             window_start = range_start
             window_end = window_start + range_length
         else:
-            window_end = range_start
-            window_start = window_end - range_length
+            window_end = range_start -(self.readout_margin-1)*self.epics_pvs['PSOEncoderCountsPerStep'].get()
+            window_start = window_end - range_length-(self.readout_margin-1)*self.epics_pvs['PSOEncoderCountsPerStep'].get()
         pso_command.put('PSOWINDOW %s 1 RANGE %d,%d' % (pso_axis, window_start-5, window_end+5), wait=True, timeout=10.0)
         # Arm the PSO
         pso_command.put('PSOCONTROL %s ARM' % pso_axis, wait=True, timeout=10.0)
@@ -325,7 +325,7 @@ class TomoScanPSO(TomoScan):
         # Assign the fly scan angular position to theta[]
         self.theta = self.rotation_start + np.arange(self.num_angles) * self.rotation_step
         
-        ##TO CHECK:
+        # When doing backwards we need to re-label the angle location so the exposure occurs at the same location
         if user_direction<0:
             self.theta+=self.rotation_step
         


### PR DESCRIPTION
This affects 
- 2-BM step scan and the wait on camera time out when doing helical scans
- 2-BM better handling of Optique Peter camera swap
- 32-ID scp/fdt automatic upload
- All beamlines: fixes backward scan projection alignment (see #160 for details)