### PR TITLE
Fix Sphinx doc build warnings 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,8 +16,6 @@
 import sys
 import os
 
-import sphinx_rtd_theme
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -129,15 +127,16 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # on_rtd is whether we are on readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# -- Options for HTML output ----------------------------------------------
+html_theme = 'sphinx_rtd_theme'
+
+# on_rtd is whether we are on readthedocs.org
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
 
 html_context = {
     "display_github": True, # Integrate GitHub
@@ -346,5 +345,6 @@ autodoc_mock_imports = [
     'pymsgbox',
     'pvaccess',
     'paramiko',
-    'serial'
+    'serial',
+    'telnetlib'
 ]

--- a/docs/source/tomoScanApp.rst
+++ b/docs/source/tomoScanApp.rst
@@ -2,9 +2,9 @@
 tomoScanApp EPICS application
 *****************************
 
-.. 
-   toctree::
+.. toctree::
    :hidden:
+   :maxdepth: 1
 
    tomoScan.template
    tomoScan_PSO.template
@@ -18,7 +18,13 @@ tomoScanApp EPICS application
    tomoScan_13BM_PSO_settings.req
    tomoScan_2BM_settings.req
    tomoScan.substitutions
-
+   tomoScan_13BM_settings.req
+   tomoScan_32ID.template
+   tomoScan_32ID_settings.req
+   tomoScan_6BM.template
+   tomoScan_6BM_settings.req
+   tomoScan_7BM.template
+   tomoScan_7BM_settings.req
 
 tomoscan includes a complete example EPICS application, including:
 
@@ -1239,13 +1245,6 @@ Pause
   * - $(P)$(R)Pause
     - bo
     - Flag allowing the scan to be paused. Choices are "GO" and "PAUSE". When set to "PAUSE", the scan will pause at begin_scan(), set the camera to continuous mode, open the shutter, and start the camera. This is used when running a long series of scans (XANES, for example), allowing for tuning and maximization of the flat-field intensity.
-
-
- record(bo, "$(P)$(R)Pause")
-  280  {
-  281     field(ZNAM, "GO")
-  282:    field(ONAM, "PAUSE")
-  283  }
 
 tomoScan_32ID_settings.req
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fix Sphinx doc build warnings  
- adding the remaining template/settings pages to a hidden toctree (instead of excluding them) so they’re registered without appearing in navigation.