### PR TITLE
Reorder move_sample_out to move Y before X

### DIFF
--- a/tomoscan/tomoscan.py
+++ b/tomoscan/tomoscan.py
@@ -462,13 +462,14 @@ class TomoScan():
 
         axis = self.epics_pvs['FlatFieldAxis'].get(as_string=True)        
         log.info('move_sample_out axis: %s', axis)
+        if axis in ('Y', 'Both'):
+            position = self.epics_pvs['SampleOutY'].value
+            self.epics_pvs['SampleY'].put(position, wait=True, timeout=600)
+
         if axis in ('X', 'Both'):
             position = self.epics_pvs['SampleOutX'].value
             self.epics_pvs['SampleX'].put(position, wait=True, timeout=600)
 
-        if axis in ('Y', 'Both'):
-            position = self.epics_pvs['SampleOutY'].value
-            self.epics_pvs['SampleY'].put(position, wait=True, timeout=600)
 
         self.epics_pvs['MoveSampleOut'].put('Done')
 


### PR DESCRIPTION
**Summary**

Adjust move_sample_out() motion order so the sample moves Y first, then X when moving out of beam. This prevents mechanical interference in setups where vertical clearance is required before lateral translation (e.g., furnace installed above the sample).

Touches tomoscan.py so feel free to close without merging if it affects your setup (we can move this into our derived classes).