### PR TITLE
Fix spurious rotation back-and-forth when collecting post-scan flat f…

### DIFF
--- a/tomoscan/tomoscan_pso.py
+++ b/tomoscan/tomoscan_pso.py
@@ -140,7 +140,11 @@ class TomoScanPSO(TomoScan):
         # Set the rotation speed to maximum
         self.epics_pvs['RotationSpeed'].put(self.max_rotation_speed)                
 
-        # Move the sample in.  Could be out if scan was aborted while taking flat fields
+        # Move the sample in (X/Y stage only).  Could be out if scan was aborted while
+        # taking flat fields.  Clear self.rotation_save first so that move_sample_in()
+        # does not restore the rotation to the end-of-scan angle — ReturnRotation in
+        # the base end_scan() handles the final rotation position.
+        self.rotation_save = None
         self.move_sample_in()
 
         # Call the base class method


### PR DESCRIPTION
When `SampleOutAngleEnable` is set to `Yes` and `FlatFieldMode` is set to `End` or `Both`,
the rotation stage performs two unnecessary extra moves at the end of the scan resulting in rotation travels `90° → 180° → 0°` instead of simply `90° → 0°`. (reported as issue #177)


Fix: clear self.rotation_save before move_sample_in() in end_scan() so only the X/Y stage is moved back. ReturnRotation in the base end_scan() handles the final rotation position.

Affects all beamlines using TomoScanPSO: 2-BM, 7-BM, 13-BM, 32-ID.