### PR TITLE
Support the new device-independent PCO records for generating triggers 

### DIFF
--- a/iocBoot/iocTomoScan_6BMB/Makefile
+++ b/iocBoot/iocTomoScan_6BMB/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+#ARCH = windows-x64-static
+ARCH = linux-x86_64
+TARGETS = envPaths dllPath.bat
+include $(TOP)/configure/RULES.ioc

--- a/iocBoot/iocTomoScan_6BMB/auto_settings.req
+++ b/iocBoot/iocTomoScan_6BMB/auto_settings.req
@@ -1,0 +1,3 @@
+file "tomoScan_settings.req", P=$(P), R=$(R)
+file "tomoScan_PSO_settings.req", P=$(P), R=$(R)
+file "tomoScan_13BM_settings.req", P=$(P), R=$(R)

--- a/iocBoot/iocTomoScan_6BMB/auto_settings.req
+++ b/iocBoot/iocTomoScan_6BMB/auto_settings.req
@@ -1,3 +1,3 @@
 file "tomoScan_settings.req", P=$(P), R=$(R)
 file "tomoScan_PSO_settings.req", P=$(P), R=$(R)
-file "tomoScan_13BM_settings.req", P=$(P), R=$(R)
+file "tomoScan_6BMB_settings.req", P=$(P), R=$(R)

--- a/iocBoot/iocTomoScan_6BMB/autosave/README
+++ b/iocBoot/iocTomoScan_6BMB/autosave/README
@@ -1,0 +1,3 @@
+This directory contains the save/restore files to retain settings between IOC reboots.
+The distribution directory does not contain a auto_settings.sav file, but this will
+be created the first time the IOC is run.

--- a/iocBoot/iocTomoScan_6BMB/save_restore.cmd
+++ b/iocBoot/iocTomoScan_6BMB/save_restore.cmd
@@ -1,0 +1,36 @@
+### save_restore setup
+#
+# The rest this file does not require modification for standard use, but...
+# If you want save_restore to manage its own NFS mount, specify the name and
+# IP address of the file server to which save files should be written.
+# This currently is supported only on vxWorks.
+#save_restoreSet_NFSHost("oxygen", "164.54.52.4")
+
+# Debug-output level
+save_restoreSet_Debug(0)
+
+# Ok to save/restore save sets with missing values (no CA connection to PV)?
+save_restoreSet_IncompleteSetsOk(1)
+# Save dated backup files?
+save_restoreSet_DatedBackupFiles(1)
+
+# Number of sequenced backup files to write
+save_restoreSet_NumSeqFiles(3)
+# Time interval between sequenced backups
+save_restoreSet_SeqPeriodInSeconds(300)
+
+# specify where save files should be
+set_savefile_path(".", "autosave")
+
+# specify what save files should be restored.  Note these files must be
+# in the directory specified in set_savefile_path(), or, if that function
+# has not been called, from the directory current when iocInit is invoked
+set_pass0_restoreFile("auto_settings.sav")
+set_pass1_restoreFile("auto_settings.sav")
+
+# specify directories in which to to search for included request files
+# Note cdCommands defines 'startup', but envPaths does not
+set_requestfile_path(".",  "")
+set_requestfile_path(".",  "autosave")
+set_requestfile_path($(AUTOSAVE), "db")
+set_requestfile_path($(TOMOSCAN), "db")

--- a/iocBoot/iocTomoScan_6BMB/st.cmd
+++ b/iocBoot/iocTomoScan_6BMB/st.cmd
@@ -1,0 +1,20 @@
+< envPaths
+
+epicsEnvSet("P", "6BMBTOMO:")
+epicsEnvSet("R", "TS:")
+
+## Register all support components
+
+# Use these lines to run the locally built tomoScanApp
+dbLoadDatabase "/corvette/home/epics/support/tomoscan/dbd/tomoScanApp.dbd"
+tomoScanApp_registerRecordDeviceDriver pdbbase
+
+dbLoadTemplate("tomoScan.substitutions")
+
+< save_restore.cmd
+save_restoreSet_status_prefix($(P))
+dbLoadRecords("$(AUTOSAVE)/asApp/Db/save_restoreStatus.db", "P=$(P)")
+
+iocInit
+
+create_monitor_set("auto_settings.req", 30, "P=$(P),R=$(R)")

--- a/iocBoot/iocTomoScan_6BMB/start_IOC
+++ b/iocBoot/iocTomoScan_6BMB/start_IOC
@@ -1,0 +1,3 @@
+# Use this line to run the locally built tomoScanApp
+cd /home/sam85/tomoscan/iocBoot/iocTomoScan_6BMB
+/corvette/home/epics/support/tomoscan/bin/linux-x86_64/tomoScanApp st.cmd

--- a/iocBoot/iocTomoScan_6BMB/start_medm
+++ b/iocBoot/iocTomoScan_6BMB/start_medm
@@ -1,0 +1,1 @@
+medm -x -macro "P=13BMDPG1:,R=TS:,BEAMLINE=tomoScan_13BM" ../../tomoScanApp/op/adl/tomoScan.adl &

--- a/iocBoot/iocTomoScan_6BMB/start_python
+++ b/iocBoot/iocTomoScan_6BMB/start_python
@@ -1,0 +1,4 @@
+#!/bin/tcsh
+conda activate base
+python -i start_tomoscan.py
+

--- a/iocBoot/iocTomoScan_6BMB/start_python.bat
+++ b/iocBoot/iocTomoScan_6BMB/start_python.bat
@@ -1,0 +1,4 @@
+CALL  C:\ProgramData\Anaconda3\Scripts\activate.bat
+python -i start_tomoscan.py
+pause
+

--- a/iocBoot/iocTomoScan_6BMB/start_tomoscan.py
+++ b/iocBoot/iocTomoScan_6BMB/start_tomoscan.py
@@ -1,0 +1,10 @@
+# This script creates an object of type TomoScan6BM_PSO for doing tomography scans at APS beamline 6-BM-B
+# To run this script type the following:
+#     python -i start_tomoscan.py
+# The -i is needed to keep Python running, otherwise it will create the object and exit
+from tomoscan.tomoscan_13bm_pso import TomoScan13BM_PSO
+ts = TomoScan6BMB_PSO(["../../db/tomoScan_settings.req",
+                       "../../db/tomoScan_PSO_settings.req", 
+                       "../../db/tomoScan_PCO_settings.req", 
+                       "../../db/tomoScan_6BMB_settings.req"], 
+                      {"$(P)":"6BMB_LVPPS1:", "$(R)":"TS:"})

--- a/iocBoot/iocTomoScan_6BMB/start_tomoscan.py
+++ b/iocBoot/iocTomoScan_6BMB/start_tomoscan.py
@@ -3,8 +3,8 @@
 #     python -i start_tomoscan.py
 # The -i is needed to keep Python running, otherwise it will create the object and exit
 from tomoscan.tomoscan_13bm_pso import TomoScan13BM_PSO
-ts = TomoScan6BMB_PSO(["../../db/tomoScan_settings.req",
-                       "../../db/tomoScan_PSO_settings.req", 
-                       "../../db/tomoScan_PCO_settings.req", 
-                       "../../db/tomoScan_6BMB_settings.req"], 
-                      {"$(P)":"6BMB_LVPPS1:", "$(R)":"TS:"})
+ts = TomoScan6BMB(["../../db/tomoScan_settings.req",
+                   "../../db/tomoScan_PSO_settings.req", 
+                   "../../db/tomoScan_PCO_settings.req", 
+                   "../../db/tomoScan_6BMB_settings.req"], 
+                   {"$(P)":"6BMBTOMO:", "$(R)":"TS:"})

--- a/iocBoot/iocTomoScan_6BMB/start_tomoscan.py
+++ b/iocBoot/iocTomoScan_6BMB/start_tomoscan.py
@@ -2,7 +2,7 @@
 # To run this script type the following:
 #     python -i start_tomoscan.py
 # The -i is needed to keep Python running, otherwise it will create the object and exit
-from tomoscan.tomoscan_13bm_pso import TomoScan13BM_PSO
+from tomoscan.tomoscan_6bmb import TomoScan6BMB
 ts = TomoScan6BMB(["../../db/tomoScan_settings.req",
                    "../../db/tomoScan_PSO_settings.req", 
                    "../../db/tomoScan_PCO_settings.req", 

--- a/iocBoot/iocTomoScan_6BMB/tomoScan.substitutions
+++ b/iocBoot/iocTomoScan_6BMB/tomoScan.substitutions
@@ -1,0 +1,28 @@
+file "$(TOMOSCAN)/db/tomoScan.template"
+{
+pattern
+{  P,        R,    CAMERA,     FILE_PLUGIN,         ROTATION,          SAMPLE_X,            SAMPLE_Y,            CLOSE_SHUTTER,        CLOSE_VALUE,        OPEN_SHUTTER,         OPEN_VALUE}
+{6BMBTOMO:,  TS:, 6BMB_LVPPS1:, 6BMB_LVPPS1:HDF1:, 6BMB_AEROTECH:m1, 6BMB_LVP:LVP:t1.EX, 6BMB_LVP:LVP:t1.EY, S06BM-PSS:SBS:CloseEPICSC,    1,        S06BM-PSS:SBS:OpenEPICSC,      1}
+}
+
+# For the Automation1 controller we use EPICS PCO, so most of the PSO macros are not used
+file "$(TOMOSCAN)/db/tomoScan_PSO.template"
+{
+pattern
+{  P,       R,   PSO_MODEL, PSO_PORT, PSO_AXIS_NAME, PSO_ENC_INPUT, PSO_ENC_PER_ROTATION}
+{6BMBTOMO:, TS:,    2,      PSO_PORT,      THETA,         2,             0}
+}
+
+file "$(TOMOSCAN)/db/tomoScan_PCO.template"
+{
+pattern
+{  P,        R,        PCO}
+{6BMBTOMO:, TS:, 6BMB_AEROTECH:m1}
+}
+
+file "$(TOMOSCAN)/db/tomoScan_6BMB.template"
+{
+pattern
+{  P,      R}
+{6BMBTOMO:, TS:}
+}

--- a/tomoScanApp/Db/tomoScan_6BMB.template
+++ b/tomoScanApp/Db/tomoScan_6BMB.template
@@ -1,0 +1,128 @@
+# Database for EPICS PVS for tomography data collection software at APS 13-BM-D
+# It contains the PVs that are required by the tomoscan_13bm derived class,
+# as well as additional PVs used for metadata about the scan that are stored
+# both in the configuration files written by tomoscan, and in the
+# files written by areaDetector file plugin.
+
+
+####################
+# Energy information
+####################
+
+record(mbbo, "$(P)$(R)EnergyMode")
+{
+   field(ZRVL, "0")
+   field(ZRST, "Mono")
+   field(ONVL, "1")
+   field(ONST, "Pink")
+   field(TWVL, "2")
+   field(TWST, "White")
+}
+
+####################
+# Optics information
+####################
+
+record(stringout, "$(P)$(R)ScintillatorType")
+{
+   field(VAL,  "Unknown")
+}
+
+record(ao, "$(P)$(R)ScintillatorThickness")
+{
+   field(PREC,  "0")
+}
+
+record(ao, "$(P)$(R)ImagePixelSize")
+{
+   field(PREC, "2")
+   field(EGU,  "microns")
+}
+
+record(ao, "$(P)$(R)DetectorPixelSize")
+{
+   field(PREC, "2")
+   field(EGU,  "microns")
+}
+
+record(stringout, "$(P)$(R)CameraObjective")
+{
+   field(VAL,  "Unknown")
+}
+
+record(ao, "$(P)$(R)CameraTubeLength")
+{
+   field(PREC, "0")
+   field(EGU,  "mm")
+}
+
+
+####################
+# Sample information
+####################
+
+record(stringout, "$(P)$(R)SampleName")
+{
+   field(VAL,  "Unknown")
+}
+
+record(stringout, "$(P)$(R)SampleDescription1")
+{
+   field(VAL,  "Unknown")
+}
+
+record(stringout, "$(P)$(R)SampleDescription2")
+{
+   field(VAL,  "Unknown")
+}
+
+record(stringout, "$(P)$(R)SampleDescription3")
+{
+   field(VAL,  "Unknown")
+}
+
+##################
+# User information
+##################
+
+record(stringout, "$(P)$(R)UserName")
+{
+   field(VAL,  "Unknown")
+}
+
+record(waveform, "$(P)$(R)UserInstitution") 
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+    field(NELM, "256")
+    field(FTVL, "CHAR")
+}
+
+record(stringout, "$(P)$(R)UserBadge")
+{
+   field(VAL,  "Unknown")
+}
+
+record(stringout, "$(P)$(R)UserEmail")
+{
+   field(VAL,  "Unknown")
+}
+
+record(stringout, "$(P)$(R)ProposalNumber")
+{
+   field(VAL,  "Unknown")
+}
+
+record(waveform, "$(P)$(R)ProposalTitle") 
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+    field(NELM, "256")
+    field(FTVL, "CHAR")
+}
+
+record(stringout, "$(P)$(R)ESAFNumber")
+{
+   field(VAL,  "Unknown")
+}
+

--- a/tomoScanApp/Db/tomoScan_6BMB_settings.req
+++ b/tomoScanApp/Db/tomoScan_6BMB_settings.req
@@ -1,0 +1,38 @@
+# This file is used by autosave to determine what PVs to save
+# It is also used by tomoScan to determine what PVs to create
+
+# This is the file for the tomoscan_6bmb derived class.
+
+####################
+# Energy information
+####################
+$(P)$(R)EnergyMode
+
+####################
+# Optics information
+####################
+$(P)$(R)ScintillatorType
+$(P)$(R)ScintillatorThickness
+$(P)$(R)ImagePixelSize
+$(P)$(R)DetectorPixelSize
+$(P)$(R)CameraObjective
+$(P)$(R)CameraTubeLength
+
+####################
+# Sample information
+####################
+$(P)$(R)SampleName
+$(P)$(R)SampleDescription1
+$(P)$(R)SampleDescription2
+$(P)$(R)SampleDescription3
+
+##################
+# User information
+##################
+$(P)$(R)UserName
+$(P)$(R)UserInstitution
+$(P)$(R)UserBadge
+$(P)$(R)UserEmail
+$(P)$(R)ProposalNumber
+$(P)$(R)ProposalTitle
+$(P)$(R)ESAFNumber

--- a/tomoScanApp/Db/tomoScan_PCO.template
+++ b/tomoScanApp/Db/tomoScan_PCO.template
@@ -1,0 +1,9 @@
+# Database for EPICS PVS for tomoScan using the EPICS motor record position compare output (PCO) support
+
+################
+# PCO Prefix
+################
+record(stringout, "$(P)$(R)PCOPVPrefix")
+{
+   field(VAL,  "$(PCO)")
+}

--- a/tomoScanApp/Db/tomoScan_PCO_settings.req
+++ b/tomoScanApp/Db/tomoScan_PCO_settings.req
@@ -1,0 +1,6 @@
+# Database for EPICS PVS for tomoScan using the EPICS motor record position compare output (PCO) support
+
+################
+# PCO Prefix
+################
+$(P)$(R)PCOPVPrefix

--- a/tomoScanApp/Db/tomoScan_PSO.template
+++ b/tomoScanApp/Db/tomoScan_PSO.template
@@ -12,6 +12,8 @@ record(mbbi, "$(P)$(R)PSOControllerModel")
     field(ZRST, "Ensemble")
     field(ONVL, "1")
     field(ONST, "A3200")
+    field(TWVL, "2")
+    field(TWST, "EPICS PCO")
     field(VAL,  "$(PSO_MODEL)")
 }
 

--- a/tomoscan/tomoscan.py
+++ b/tomoscan/tomoscan.py
@@ -188,7 +188,7 @@ class TomoScan():
         self.control_pvs['FPFileWriteMode'].put('Stream')
         self.control_pvs['FPEnableCallbacks'].put('Enable')
 
-        #Define PVs from the MCS or PSO that live on another IOC
+        #Define PVs from the MCS or PCO that live on another IOC
         if 'MCS' in self.pv_prefixes:
             prefix = self.pv_prefixes['MCS']
             self.control_pvs['MCSEraseStart']      = PV(prefix + 'EraseStart')
@@ -199,6 +199,14 @@ class TomoScan():
             self.control_pvs['MCSChannelAdvance']  = PV(prefix + 'ChannelAdvance')
             self.control_pvs['MCSMaxChannels']     = PV(prefix + 'MaxChannels')
             self.control_pvs['MCSNuseAll']         = PV(prefix + 'NuseAll')
+
+        if 'PCO' in self.pv_prefixes:
+            prefix = self.pv_prefixes['PCO']
+            print('PCO prefix=', prefix)
+            self.control_pvs['PCOStartPosition']   = PV(prefix + 'PCOStartPosition')
+            self.control_pvs['PCOEndPosition']     = PV(prefix + 'PCOEndPosition')
+            self.control_pvs['PCOIncrement']       = PV(prefix + 'PCOIncrement')
+            self.control_pvs['PCOEnable']          = PV(prefix + 'PCOEnable')
 
         if 'PvaPlugin' in self.pv_prefixes:
             prefix = self.pv_prefixes['PvaPlugin']
@@ -406,6 +414,7 @@ class TomoScan():
             for key in macros:
                 dictentry = dictentry.replace(key, '')
             epics_pv = PV(pvname)
+            print('pvname=', pvname)
             if is_config_pv:
                 self.config_pvs[dictentry] = epics_pv
             else:
@@ -416,7 +425,9 @@ class TomoScan():
                 self.control_pvs[key] = PV(pvname)
             if dictentry.find('PVPrefix') != -1:
                 pvprefix = epics_pv.value
+                print('pvprefix=', pvprefix)
                 key = dictentry.replace('PVPrefix', '')
+                print('key=', key)
                 self.pv_prefixes[key] = pvprefix
 
     def move_sample_in(self):

--- a/tomoscan/tomoscan.py
+++ b/tomoscan/tomoscan.py
@@ -202,7 +202,6 @@ class TomoScan():
 
         if 'PCO' in self.pv_prefixes:
             prefix = self.pv_prefixes['PCO']
-            print('PCO prefix=', prefix)
             self.control_pvs['PCOStartPosition']   = PV(prefix + 'PCOStartPosition')
             self.control_pvs['PCOEndPosition']     = PV(prefix + 'PCOEndPosition')
             self.control_pvs['PCOIncrement']       = PV(prefix + 'PCOIncrement')
@@ -414,7 +413,6 @@ class TomoScan():
             for key in macros:
                 dictentry = dictentry.replace(key, '')
             epics_pv = PV(pvname)
-            print('pvname=', pvname)
             if is_config_pv:
                 self.config_pvs[dictentry] = epics_pv
             else:
@@ -425,9 +423,7 @@ class TomoScan():
                 self.control_pvs[key] = PV(pvname)
             if dictentry.find('PVPrefix') != -1:
                 pvprefix = epics_pv.value
-                print('pvprefix=', pvprefix)
                 key = dictentry.replace('PVPrefix', '')
-                print('key=', key)
                 self.pv_prefixes[key] = pvprefix
 
     def move_sample_in(self):

--- a/tomoscan/tomoscan_6bmb.py
+++ b/tomoscan/tomoscan_6bmb.py
@@ -1,0 +1,80 @@
+"""Software for tomography scanning with EPICS at APS beamline 6-BM-B
+
+   Classes
+   -------
+   TomoScan6BMB
+     Derived class for tomography scanning with EPICS at APS beamline 6-BM-B
+     using the Aerotech Automation1 as the rotation stage and trigger source  
+"""
+import time
+import math
+import os
+from tomoscan.tomoscan_pso import TomoScanPSO
+from tomoscan import log
+from epics import caput
+
+class TomoScan6BMB(TomoScanPSO):
+    """Derived class used for tomography scanning with EPICS at APS beamline 6-BM-B
+       using the Aerotech Automation1 as the rotation stage and trigger source
+
+    Parameters
+    ----------
+    pv_files : list of str
+        List of files containing EPICS pvNames to be used.
+    macros : dict
+        Dictionary of macro definitions to be substituted when
+        reading the pv_files
+    """
+
+    def __init__(self, pv_files, macros):
+        super().__init__(pv_files, macros)
+
+        # Set the detector running in FreeRun mode
+        self.set_trigger_mode('FreeRun', 1)
+
+    def set_trigger_mode(self, trigger_mode, num_images):
+        """Sets the trigger mode of the camera.
+
+        Parameters
+        ----------
+        trigger_mode : str
+            Choices are: "FreeRun", "Internal", or "PSOExternal"
+
+        num_images : int
+            Number of images to collect.  Ignored if trigger_mode="FreeRun".
+            This is used to set the ``NumImages`` PV of the camera.
+        """
+        log.info('set trigger mode: %s', trigger_mode)
+        # Stop acquisition if we are acquiring
+        self.epics_pvs['CamAcquire'].put('Done', wait=True)
+        manufacturer = self.control_pvs['CamManufacturer'].get(as_string=True)
+        model = self.control_pvs['CamModel'].get(as_string=True)
+        if (manufacturer.find('Point Grey') != -1) or (manufacturer.find('FLIR') != -1):
+            if trigger_mode == 'FreeRun':
+                self.epics_pvs['CamImageMode'].put('Continuous', wait=True)
+                self.epics_pvs['CamTriggerMode'].put('Off', wait=True)
+                self.epics_pvs['CamAcquire'].put('Acquire')
+            elif trigger_mode == 'Internal':
+                self.epics_pvs['CamTriggerMode'].put('Off', wait=True)
+                self.epics_pvs['CamImageMode'].put('Multiple')
+                self.epics_pvs['CamNumImages'].put(num_images, wait=True)
+            else: # set camera to external triggering
+                self.epics_pvs['CamNumImages'].put(num_images, wait=True)
+                self.epics_pvs['CamTriggerMode'].put('On', wait=True)
+                self.epics_pvs['CamExposureMode'].put('Timed', wait=True)
+                self.epics_pvs['CamTriggerOverlap'].put('ReadOut', wait=True)
+                # There is a problem with the Grasshopper3 when switching to external trigger mode.
+                # The first 3 images are bad, at least at long exposure times.
+                # We take 3 dummy frames with Software trigger mode and don't save them to HDF5 file.
+                self.epics_pvs['CamImageMode'].put('Single', wait=True)
+                self.epics_pvs['CamTriggerSource'].put('Software', wait=True)
+                exposure = self.epics_pvs['CamAcquireTimeRBV'].value
+                self.epics_pvs['FPEnableCallbacks'].put('Disable', wait=True)
+                for i in range(3):
+                    self.epics_pvs['CamAcquire'].put('Acquire')
+                    time.sleep(.1)
+                    self.epics_pvs['CamTriggerSoftware'].put(1, wait=True)
+                    self.wait_camera_done(exposure + 5)
+                self.epics_pvs['FPEnableCallbacks'].put('Enable', wait=True)
+                self.epics_pvs['CamImageMode'].put('Multiple', wait=True)
+                self.epics_pvs['CamTriggerSource'].put('Line0', wait=True)

--- a/tomoscan/tomoscan_pso.py
+++ b/tomoscan/tomoscan_pso.py
@@ -225,6 +225,9 @@ class TomoScanPSO(TomoScan):
         elif (pso_model == 'A3200'):
             pso_command.put('PSOOUTPUT %s CONTROL 0 1' % pso_axis, wait=True, timeout=10.0)
         if (pso_model == 'EPICS PCO'):
+             self.epics_pvs['PCOStartPosition'].put(self.rotation_start)
+             self.epics_pvs['PCOEndPosition'].put(self.rotation_stop)
+             self.epics_pvs['PCOIncrement'].put(self.rotation_step)
              self.epics_pvs['PCOEnable'].put(1)
         else:
             # Set the pulse width.  The total width and active width are the same, since this is a single pulse.

--- a/tomoscan/tomoscan_pso.py
+++ b/tomoscan/tomoscan_pso.py
@@ -203,10 +203,11 @@ class TomoScanPSO(TomoScan):
         overall_sense, user_direction = self._compute_senses()
         log.info(f'Overall sense = {overall_sense}')
         log.info(f'User direction = {user_direction}')
-        pso_command = self.epics_pvs['PSOCommand.BOUT']
         pso_model = self.epics_pvs['PSOControllerModel'].get(as_string=True)
-        pso_axis = self.epics_pvs['PSOAxisName'].get(as_string=True)
-        pso_input = int(self.epics_pvs['PSOEncoderInput'].get(as_string=True))
+        if (pso_model != 'EPICS PCO'):
+            pso_command = self.epics_pvs['PSOCommand.BOUT']
+            pso_axis = self.epics_pvs['PSOAxisName'].get(as_string=True)
+            pso_input = int(self.epics_pvs['PSOEncoderInput'].get(as_string=True))
 
         # Place the motor at the position where the first PSO pulse should be triggered
         self.epics_pvs['RotationSpeed'].put(self.max_rotation_speed)
@@ -214,40 +215,46 @@ class TomoScanPSO(TomoScan):
         self.epics_pvs['RotationSpeed'].put(self.motor_speed)
 
         # Make sure the PSO control is off
-        pso_command.put('PSOCONTROL %s RESET' % pso_axis, wait=True, timeout=10.0)
+        if (pso_model == 'EPICS PCO'):
+            self.epics_pvs['PCOEnable'].put(0)
+        else:
+            pso_command.put('PSOCONTROL %s RESET' % pso_axis, wait=True, timeout=10.0)
         # Set the output to occur from the I/O terminal on the controller
         if (pso_model == 'Ensemble'):
             pso_command.put('PSOOUTPUT %s CONTROL 1' % pso_axis, wait=True, timeout=10.0)
         elif (pso_model == 'A3200'):
             pso_command.put('PSOOUTPUT %s CONTROL 0 1' % pso_axis, wait=True, timeout=10.0)
-        # Set the pulse width.  The total width and active width are the same, since this is a single pulse.
-        pulse_width = self.epics_pvs['PSOPulseWidth'].get()
-        pso_command.put('PSOPULSE %s TIME %f,%f' % (pso_axis, pulse_width, pulse_width), wait=True, timeout=10.0)
-        # Set the pulses to only occur in a specific window
-        pso_command.put('PSOOUTPUT %s PULSE WINDOW MASK' % pso_axis, wait=True, timeout=10.0)
-        # Set which encoder we will use.  3 = the MXH (encoder multiplier) input, which is what we generally want
-        pso_command.put('PSOTRACK %s INPUT %d' % (pso_axis, pso_input), wait=True, timeout=10.0)
-        # Set the distance between pulses. Do this in encoder counts.
-        pso_command.put('PSODISTANCE %s FIXED %d' % (pso_axis, 
-                        int(np.abs(self.epics_pvs['PSOEncoderCountsPerStep'].get()))) , wait=True, timeout=10.0)
-        # Which encoder is being used to calculate whether we are in the window.  1 for single axis
-        pso_command.put('PSOWINDOW %s 1 INPUT %d' % (pso_axis, pso_input), wait=True, timeout=10.0)
-
-        # Calculate window function parameters.  Must be in encoder counts, and is 
-        # referenced from the stage location where we arm the PSO.  We are at that point now.
-        # We want pulses to start at start - delta/2, end at end + delta/2.  
-        range_start = -round(np.abs(self.epics_pvs['PSOEncoderCountsPerStep'].get())/ 2) * overall_sense
-        range_length = np.abs(self.epics_pvs['PSOEncoderCountsPerStep'].get()) * (self.num_angles+1)
-        # The start of the PSO window must be < end.  Handle this.
-        if overall_sense > 0:
-            window_start = range_start
-            window_end = window_start + range_length
+        if (pso_model == 'EPICS PCO'):
+             self.epics_pvs['PCOEnable'].put(1)
         else:
-            window_end = range_start
-            window_start = window_end - range_length
-        pso_command.put('PSOWINDOW %s 1 RANGE %d,%d' % (pso_axis, window_start-5, window_end+5), wait=True, timeout=10.0)
-        # Arm the PSO
-        pso_command.put('PSOCONTROL %s ARM' % pso_axis, wait=True, timeout=10.0)
+            # Set the pulse width.  The total width and active width are the same, since this is a single pulse.
+            pulse_width = self.epics_pvs['PSOPulseWidth'].get()
+            pso_command.put('PSOPULSE %s TIME %f,%f' % (pso_axis, pulse_width, pulse_width), wait=True, timeout=10.0)
+            # Set the pulses to only occur in a specific window
+            pso_command.put('PSOOUTPUT %s PULSE WINDOW MASK' % pso_axis, wait=True, timeout=10.0)
+            # Set which encoder we will use.  3 = the MXH (encoder multiplier) input, which is what we generally want
+            pso_command.put('PSOTRACK %s INPUT %d' % (pso_axis, pso_input), wait=True, timeout=10.0)
+            # Set the distance between pulses. Do this in encoder counts.
+            pso_command.put('PSODISTANCE %s FIXED %d' % (pso_axis, 
+                            int(np.abs(self.epics_pvs['PSOEncoderCountsPerStep'].get()))) , wait=True, timeout=10.0)
+            # Which encoder is being used to calculate whether we are in the window.  1 for single axis
+            pso_command.put('PSOWINDOW %s 1 INPUT %d' % (pso_axis, pso_input), wait=True, timeout=10.0)
+
+            # Calculate window function parameters.  Must be in encoder counts, and is 
+            # referenced from the stage location where we arm the PSO.  We are at that point now.
+            # We want pulses to start at start - delta/2, end at end + delta/2.  
+            range_start = -round(np.abs(self.epics_pvs['PSOEncoderCountsPerStep'].get())/ 2) * overall_sense
+            range_length = np.abs(self.epics_pvs['PSOEncoderCountsPerStep'].get()) * (self.num_angles+1)
+            # The start of the PSO window must be < end.  Handle this.
+            if overall_sense > 0:
+                window_start = range_start
+                window_end = window_start + range_length
+            else:
+                window_end = range_start
+                window_start = window_end - range_length
+            pso_command.put('PSOWINDOW %s 1 RANGE %d,%d' % (pso_axis, window_start-5, window_end+5), wait=True, timeout=10.0)
+            # Arm the PSO
+            pso_command.put('PSOCONTROL %s ARM' % pso_axis, wait=True, timeout=10.0)
 
     def cleanup_PSO(self):
         '''Cleanup activities after a PSO scan. 
@@ -255,13 +262,16 @@ class TomoScanPSO(TomoScan):
         '''
         log.info('Cleaning up PSO programming.')
         pso_model = self.epics_pvs['PSOControllerModel'].get(as_string=True)
-        pso_command = self.epics_pvs['PSOCommand.BOUT']
-        pso_axis = self.epics_pvs['PSOAxisName'].get(as_string=True)
-        if (pso_model == 'Ensemble'):
-            pso_command.put('PSOWINDOW %s OFF' % pso_axis, wait=True)
-        elif (pso_model == 'A3200'):
-            pso_command.put('PSOWINDOW %s 1 OFF' % pso_axis, wait=True)
-        pso_command.put('PSOCONTROL %s OFF' % pso_axis, wait=True)
+        if (pso_model == 'EPICS PCO'):
+            self.epics_pvs['PCOEnable'].put(0)
+        else:
+            pso_command = self.epics_pvs['PSOCommand.BOUT']
+            pso_axis = self.epics_pvs['PSOAxisName'].get(as_string=True)
+            if (pso_model == 'Ensemble'):
+                pso_command.put('PSOWINDOW %s OFF' % pso_axis, wait=True)
+            elif (pso_model == 'A3200'):
+                pso_command.put('PSOWINDOW %s 1 OFF' % pso_axis, wait=True)
+            pso_command.put('PSOCONTROL %s OFF' % pso_axis, wait=True)
 
     def _compute_senses(self):
         '''Computes whether this motion will be increasing or decreasing encoder counts.
@@ -289,18 +299,20 @@ class TomoScanPSO(TomoScan):
         '''
         overall_sense, user_direction = self._compute_senses()
         
-        # Compute the actual delta to keep each interval an integer number of encoder counts
-        encoder_multiply = float(self.epics_pvs['PSOCountsPerRotation'].get()) / 360.
-        raw_delta_encoder_counts = self.rotation_step * encoder_multiply
-        delta_encoder_counts = round(raw_delta_encoder_counts)
-        if abs(raw_delta_encoder_counts - delta_encoder_counts) > 1e-4:
-            log.warning('  *** *** *** Requested scan would have used a non-integer number of encoder counts.')
-            log.warning('  *** *** *** Calculated # of encoder counts per step = {0:9.4f}'.format(raw_delta_encoder_counts))
-            log.warning('  *** *** *** Instead, using {0:d}'.format(delta_encoder_counts))
-        self.epics_pvs['PSOEncoderCountsPerStep'].put(delta_encoder_counts)
-        # Change the rotation step Python variable and PV
-        self.rotation_step = delta_encoder_counts / encoder_multiply
-        self.epics_pvs['RotationStep'].put(self.rotation_step)
+        pso_model = self.epics_pvs['PSOControllerModel'].get(as_string=True)
+        if (pso_model != 'EPICS PCO'):
+            # Compute the actual delta to keep each interval an integer number of encoder counts
+            encoder_multiply = float(self.epics_pvs['PSOCountsPerRotation'].get()) / 360.
+            raw_delta_encoder_counts = self.rotation_step * encoder_multiply
+            delta_encoder_counts = round(raw_delta_encoder_counts)
+            if abs(raw_delta_encoder_counts - delta_encoder_counts) > 1e-4:
+                log.warning('  *** *** *** Requested scan would have used a non-integer number of encoder counts.')
+                log.warning('  *** *** *** Calculated # of encoder counts per step = {0:9.4f}'.format(raw_delta_encoder_counts))
+                log.warning('  *** *** *** Instead, using {0:d}'.format(delta_encoder_counts))
+            self.epics_pvs['PSOEncoderCountsPerStep'].put(delta_encoder_counts)
+            # Change the rotation step Python variable and PV
+            self.rotation_step = delta_encoder_counts / encoder_multiply
+            self.epics_pvs['RotationStep'].put(self.rotation_step)
                 
         # Compute the time for each frame
         time_per_angle = self.compute_frame_time()

--- a/tomoscan/tomoscan_pso.py
+++ b/tomoscan/tomoscan_pso.py
@@ -226,7 +226,8 @@ class TomoScanPSO(TomoScan):
             pso_command.put('PSOOUTPUT %s CONTROL 0 1' % pso_axis, wait=True, timeout=10.0)
         if (pso_model == 'EPICS PCO'):
              self.epics_pvs['PCOStartPosition'].put(self.rotation_start)
-             self.epics_pvs['PCOEndPosition'].put(self.rotation_stop)
+             pulse_end = self.rotation_start + (self.num_angles * self.rotation_step)
+             self.epics_pvs['PCOEndPosition'].put(pulse_end)
              self.epics_pvs['PCOIncrement'].put(self.rotation_step)
              self.epics_pvs['PCOEnable'].put(1)
         else:


### PR DESCRIPTION
The existing code in tomoscan_pso.py talks directly to the Ensemble and A3200 controllers for configuring the PSO trigger outputs from the rotation stage.  This is not a clean solution, and does not work for other controllers, including the Aerotech Automation1, which requires function calls rather than strings.

I have extended the Model 3 API in the motor module to support position compare output (PCO) in a device-independent way.  The generic records are PCOStartPosition, PCOEndPosition, PCOIncrement, and PCOPulseWidth.  Some controllers support additional records for advanced features.  This new API is currently implemented for:
- Aerotech Automation1
- Newport XPS
- Galil DMC-41x3

This PR adds support for these PCO records in tomoscan.py and tomoscan_pso.py.

It also adds support for the APS 6-BM-B station, which uses this support for an Aerotech Automation1 controller.
- tomoscan/tomoscan-6bmb.py
- tomoscan/iocBoot/iocTomoScan_6BMB