### PR TITLE
Add PINI=YES to the records named in the settings request files

### DIFF
--- a/tomoScanApp/Db/tomoScan.template
+++ b/tomoScanApp/Db/tomoScan.template
@@ -8,11 +8,13 @@
 record(stringout, "$(P)$(R)CameraPVPrefix")
 {
    field(VAL,  "$(CAMERA)")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)FilePluginPVPrefix")
 {
    field(VAL,  "$(FILE_PLUGIN)")
+   field(PINI, "YES")
 }
 
 #################
@@ -22,27 +24,32 @@ record(stringout, "$(P)$(R)FilePluginPVPrefix")
 record(stringout, "$(P)$(R)CloseShutterPVName")
 {
    field(VAL,  "$(CLOSE_SHUTTER)")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)CloseShutterValue")
 {
    field(VAL,  "$(CLOSE_VALUE)")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)OpenShutterPVName")
 {
    field(VAL,  "$(OPEN_SHUTTER)")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)OpenShutterValue")
 {
    field(VAL,  "$(OPEN_VALUE)")
+   field(PINI, "YES")
 }
 
 record(bo, "$(P)$(R)AutoCloseShutter")
 {
    field(ZNAM,  "No")
    field(ONAM,  "Yes")
+   field(PINI, "YES")
 }
 
 record(bo, "$(P)$(R)CloseShutterCmd")
@@ -61,16 +68,19 @@ record(bo, "$(P)$(R)OpenShutterCmd")
 record(stringout, "$(P)$(R)RotationPVName")
 {
    field(VAL,  "$(ROTATION)")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)SampleXPVName")
 {
    field(VAL,  "$(SAMPLE_X)")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)SampleYPVName")
 {
    field(VAL,  "$(SAMPLE_Y)")
+   field(PINI, "YES")
 }
 
 
@@ -85,11 +95,13 @@ record(stringout, "$(P)$(R)SampleYPVName")
 record(ao, "$(P)$(R)RotationStart")
 {
    field(PREC,  "3")
+   field(PINI, "YES")
 }
 
 record(ao, "$(P)$(R)RotationStep")
 {
    field(PREC,  "3")
+   field(PINI, "YES")
 }
 
 record(calc, "$(P)$(R)RotationStop")
@@ -103,6 +115,7 @@ record(calc, "$(P)$(R)RotationStop")
 
 record(longout, "$(P)$(R)NumAngles")
 {
+   field(PINI, "YES")
 }
 
 record(mbbo, "$(P)$(R)ReturnRotation")
@@ -113,6 +126,7 @@ record(mbbo, "$(P)$(R)ReturnRotation")
    field(ONST, "Yes")
    field(TWVL, "2")
    field(TWST, "Home")
+   field(PINI, "YES")
 }
 
 ####################
@@ -121,6 +135,7 @@ record(mbbo, "$(P)$(R)ReturnRotation")
 
 record(longout, "$(P)$(R)NumDarkFields")
 {
+   field(PINI, "YES")
 }
 
 record(mbbo, "$(P)$(R)DarkFieldMode")
@@ -133,11 +148,13 @@ record(mbbo, "$(P)$(R)DarkFieldMode")
    field(TWST, "Both")
    field(THVL, "3")
    field(THST, "None")
+   field(PINI, "YES")
 }
 
 record(ao, "$(P)$(R)DarkFieldValue")
 {
    field(PREC,  "0")
+   field(PINI, "YES")
 }
 
 ####################
@@ -146,6 +163,7 @@ record(ao, "$(P)$(R)DarkFieldValue")
 
 record(longout, "$(P)$(R)NumFlatFields")
 {
+   field(PINI, "YES")
 }
 
 record(mbbo, "$(P)$(R)FlatFieldMode")
@@ -158,6 +176,7 @@ record(mbbo, "$(P)$(R)FlatFieldMode")
    field(TWST, "Both")
    field(THVL, "3")
    field(THST, "None")
+   field(PINI, "YES")
 }
 
 record(mbbo, "$(P)$(R)FlatFieldAxis")
@@ -168,42 +187,50 @@ record(mbbo, "$(P)$(R)FlatFieldAxis")
    field(ONST, "Y")
    field(TWVL, "3")
    field(TWST, "Both")
+   field(PINI, "YES")
 }
 
 record(ao, "$(P)$(R)FlatFieldValue")
 {
    field(PREC,  "0")
+   field(PINI, "YES")
 }
 
 record(ao, "$(P)$(R)SampleInX")
 {
    field(PREC,  "3")
+   field(PINI, "YES")
 }
 
 record(ao, "$(P)$(R)SampleOutX")
 {
    field(PREC,  "3")
+   field(PINI, "YES")
 }
 
 record(ao, "$(P)$(R)SampleInY")
 {
    field(PREC,  "3")
+   field(PINI, "YES")
 }
 
 record(ao, "$(P)$(R)SampleOutY")
 {
    field(PREC,  "3")
+   field(PINI, "YES")
 }
 
 record(ao, "$(P)$(R)SampleOutAngle")
 {
    field(PREC,  "3")
+   field(PINI, "YES")
 }
 
 record(bo, "$(P)$(R)SampleOutAngleEnable")
 {
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   field(PINI, "YES")
 }
 
 ############
@@ -227,17 +254,20 @@ record(mbbi, "$(P)$(R)FrameType")
 record(ao, "$(P)$(R)ExposureTime")
 {
    field(PREC,  "3")
+   field(PINI, "YES")
 }
 
 record(ao, "$(P)$(R)FlatExposureTime")
 {
    field(PREC,  "3")
+   field(PINI, "YES")
 }
 
 record(bo, "$(P)$(R)DifferentFlatExposure")
 {
    field(ZNAM, "Same")
    field(ONAM, "Different")
+   field(PINI, "YES")
 }
 
 ############################
@@ -248,12 +278,14 @@ record(waveform, "$(P)$(R)FilePath")
 {
    field(FTVL, "UCHAR")
    field(NELM, "256")
+   field(PINI, "YES")
 }
 
 record(waveform, "$(P)$(R)FileName")
 {
    field(FTVL, "UCHAR")
    field(NELM, "256")
+   field(PINI, "YES")
 }
 
 record(bi, "$(P)$(R)FilePathExists")
@@ -270,12 +302,14 @@ record(bi, "$(P)$(R)OverwriteWarning")
     field(ZSV,  "MAJOR")
     field(ONAM, "Yes")
     field(OSV,  "NO_ALARM")
+   field(PINI, "YES")
 }
 
 record(waveform, "$(P)$(R)FullFileName")
 {
    field(FTVL, "UCHAR")
    field(NELM, "256")
+   field(PINI, "YES")
 }
 
 ################################
@@ -396,10 +430,12 @@ record(mbbo, "$(P)$(R)ScanType")
    field(SXST, "Energy File")
    field(SVVL, "7")
    field(SVST, "Helical")
+   field(PINI, "YES")
 }
 
 record(bo, "$(P)$(R)FlipStitch")
 {
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   field(PINI, "YES")
 }

--- a/tomoScanApp/Db/tomoScan_2BM.template
+++ b/tomoScanApp/Db/tomoScan_2BM.template
@@ -11,17 +11,20 @@
 record(stringout, "$(P)$(R)BeamReadyPVName")
 {
    field(VAL,  "$(BEAM_READY)")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)BeamReadyValue")
 {
    field(VAL,  "$(READY_VALUE)")
+   field(PINI, "YES")
 }
 
 record(bo, "$(P)$(R)Testing")
 {
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   field(PINI, "YES")
 }
 
 ####################
@@ -31,21 +34,25 @@ record(bo, "$(P)$(R)Testing")
 record(stringout, "$(P)$(R)SampleName")
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)SampleDescription1")
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)SampleDescription2")
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)SampleDescription3")
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 ##################
@@ -55,6 +62,7 @@ record(stringout, "$(P)$(R)SampleDescription3")
 record(stringout, "$(P)$(R)UserName")
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 record(waveform, "$(P)$(R)UserInstitution") 
@@ -63,21 +71,25 @@ record(waveform, "$(P)$(R)UserInstitution")
     field(DTYP, "Soft Channel")
     field(NELM, "256")
     field(FTVL, "CHAR")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)UserBadge")
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)UserEmail")
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)ProposalNumber")
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 record(waveform, "$(P)$(R)ProposalTitle") 
@@ -86,16 +98,19 @@ record(waveform, "$(P)$(R)ProposalTitle")
     field(DTYP, "Soft Channel")
     field(NELM, "256")
     field(FTVL, "CHAR")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)ESAFNumber")
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)UserInfoUpdate")
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 
@@ -106,21 +121,25 @@ record(stringout, "$(P)$(R)UserInfoUpdate")
 record(stringout, "$(P)$(R)DetectorTopDir") 
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)UserLastName")
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)ExperimentYearMonth")
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)RemoteAnalysisDir") 
 {
    field(VAL,  "Unknown")
+   field(PINI, "YES")
 }
 
 record(mbbo, "$(P)$(R)CopyToAnalysisDir")
@@ -131,6 +150,7 @@ record(mbbo, "$(P)$(R)CopyToAnalysisDir")
    field(ONST, "fdt")
    field(TWVL, "2")
    field(TWST, "scp")
+   field(PINI, "YES")
 }
 
 
@@ -141,21 +161,25 @@ record(mbbo, "$(P)$(R)CopyToAnalysisDir")
 record(stringout, "$(P)$(R)CloseFastShutterPVName")
 {
    field(VAL,  "$(CLOSE_FAST_SHUTTER)")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)CloseFastShutterValue")
 {
    field(VAL,  "$(CLOSE_FAST_VALUE)")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)OpenFastShutterPVName")
 {
    field(VAL,  "$(OPEN_FAST_SHUTTER)")
+   field(PINI, "YES")
 }
 
 record(stringout, "$(P)$(R)OpenFastShutterValue")
 {
    field(VAL,  "$(OPEN_FAST_VALUE)")
+   field(PINI, "YES")
 }
 
 ################
@@ -165,6 +189,7 @@ record(stringout, "$(P)$(R)OpenFastShutterValue")
 record(stringout, "$(P)$(R)ShutterStatusPVName")
 {
    field(VAL,  "$(SHUTTER_STATUS)")
+   field(PINI, "YES")
 }
 
 ###########
@@ -174,6 +199,7 @@ record(stringout, "$(P)$(R)ShutterStatusPVName")
 record(stringout, "$(P)$(R)MctOpticsPVPrefix")
 {
    field(VAL,  "$(MCT_OPTICS)")
+   field(PINI, "YES")
 }
 
 ############
@@ -194,12 +220,14 @@ record(mbbo, "$(P)$(R)ScanType")
    field(FRST, "File")
    field(FVVL, "5")
    field(FVST, "Energy")
+   field(PINI, "YES")
 }
 
 record(bo, "$(P)$(R)FlipStitch")
 {
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   field(PINI, "YES")
 }
 
 
@@ -210,6 +238,7 @@ record(bo, "$(P)$(R)FlipStitch")
 record(stringout, "$(P)$(R)PvaPluginPVPrefix")
 {
    field(VAL,  "$(PVA_PLUGIN)")
+   field(PINI, "YES")
 }
 
 ######################
@@ -219,6 +248,7 @@ record(stringout, "$(P)$(R)PvaPluginPVPrefix")
 record(stringout, "$(P)$(R)RoiPluginPVPrefix")
 {
    field(VAL,  "$(ROI_PLUGIN)")
+   field(PINI, "YES")
 }
 
 #####################
@@ -228,4 +258,5 @@ record(stringout, "$(P)$(R)RoiPluginPVPrefix")
 record(stringout, "$(P)$(R)CbPluginPVPrefix")
 {
    field(VAL,  "$(CB_PLUGIN)")
+   field(PINI, "YES")
 }


### PR DESCRIPTION
Addresses #182. Autosave restores these records at boot without processing them, so they come back with the right value but no EPICS timestamp and `STAT` still at `UDF`. A client recording scan provenance cannot date the setting.

`PINI=YES` makes each record process once at `iocInit`, which runs after both autosave restore passes (`initHookAfterInitDevSup` and `initHookAfterInitDatabase`), so it is the *restored* value that gets stamped, not the default.

**Scope.** Exactly the records listed in `tomoScan_settings.req` and `tomoScan_2BM_settings.req`, 67 records across the two templates. None has an `OUT`, `INP`, `DOL`, `FLNK` or `SDIS` field, so processing writes nothing out, reads nothing in, and triggers nothing downstream. The `busy` command records @MarkRivers flagged (`StartScan`, `AbortScan`, `MoveSampleIn`, `MoveSampleOut`) are commented out of the request file and are not in scope.

**Verified** on a scratch IOC, base 7.0.8 with autosave R5-11, across a real restart:

```
record       PINI   value after reboot        UDF  SEVR       TIME
------------------------------------------------------------------------
ao_pini      YES    42.5                      0    NO_ALARM   2026-08-19 16:26:42
ao_nopini    no     43.5                      0    NO_ALARM   <undefined>
wf_pini      YES    /data/2026-08/sampleA     0    NO_ALARM   2026-08-19 16:26:42
wf_nopini    no     /data/2026-08/sampleB     1    INVALID    <undefined>
```

The waveform case was the one I most wanted to check, since PINI makes a `waveform` process and its device support read `INP`. With Soft Channel and an empty `INP`, `read_wf()` returns immediately without touching `bptr` or `nord`, so the restored buffer survives, as the table shows.

Happy to extend to the other beamline templates once this shape is agreed. Worth applying after #185, which fixes the request files that silently drop their last PV.