### PR TITLE
Let super().end_scan() run even if the 2BM optional steps fail

### DIFF
--- a/tomoscan/tomoscan_2bm.py
+++ b/tomoscan/tomoscan_2bm.py
@@ -525,48 +525,56 @@ class TomoScan2BM(TomoScanHelical):
         # Add theta in the hdf file
         self.add_theta()
 
-        log.info('Adding a frame from the IP camera')
+        try:
+            log.info('Adding a frame from the IP camera')
 
-        with open(CREDENTIALS_FILE_NAME, 'r') as file:
-            for line in file:
-                username, password = line.strip().split('|')  
+            with open(CREDENTIALS_FILE_NAME, 'r') as file:
+                for line in file:
+                    username, password = line.strip().split('|')
 
 
-        ret, frame = cv2.VideoCapture('http://' + username +':' + password + '@10.54.113.162/cgi-bin/mjpeg?stream=1').read()
-        #station A        
-        # NetBooter = NetBooter_Control(mode='telnet',id=self.access_dic['pdu_username'],password=self.access_dic['pdu_password'],ip=self.access_dic['pdu_ip_address'])
-        # NetBooter.power_on(1)
-        # log.info('wait 10 sec while the web camera has focused')
-        # time.sleep(10)                       
-        # ret, frame = cv2.VideoCapture('http://remotecam02bma:Cam-02-bm-a@164.54.113.137/cgi-bin/mjpeg?stream=1').read()# we should hide the password
-        #ret, frame = cv2.VideoCapture('http://' + self.access_dic['webcam_username'] +':' + self.access_dic['webcam_password'] + '@' + self.access_dic['webcam_ip_address'] + '/cgi-bin/mjpeg?stream=1').read()
-        # NetBooter.power_off(1)                       
-        
+            ret, frame = cv2.VideoCapture('http://' + username +':' + password + '@10.54.113.162/cgi-bin/mjpeg?stream=1').read()
+            #station A
+            # NetBooter = NetBooter_Control(mode='telnet',id=self.access_dic['pdu_username'],password=self.access_dic['pdu_password'],ip=self.access_dic['pdu_ip_address'])
+            # NetBooter.power_on(1)
+            # log.info('wait 10 sec while the web camera has focused')
+            # time.sleep(10)
+            # ret, frame = cv2.VideoCapture('http://remotecam02bma:Cam-02-bm-a@164.54.113.137/cgi-bin/mjpeg?stream=1').read()# we should hide the password
+            #ret, frame = cv2.VideoCapture('http://' + self.access_dic['webcam_username'] +':' + self.access_dic['webcam_password'] + '@' + self.access_dic['webcam_ip_address'] + '/cgi-bin/mjpeg?stream=1').read()
+            # NetBooter.power_off(1)
 
-        if ret==True:
+
+            if ret==True:
+                full_file_name = self.epics_pvs['FPFullFileName'].get(as_string=True)
+                with h5py.File(full_file_name,'r+') as fid:
+                    fid.create_dataset('exchange/web_camera_frame', data=frame)
+                log.info('The frame was added')
+            else:
+                log.warning('The frame was not added')
+        except:
+            log.error('Failed to add the web camera frame to the scan file')
+            traceback.print_exc(file=sys.stdout)
+
+        try:
+            # Copy raw data to data analysis computer
+            log.info('Automatic data trasfer to data analysis computer is enabled.')
             full_file_name = self.epics_pvs['FPFullFileName'].get(as_string=True)
-            with h5py.File(full_file_name,'r+') as fid:
-                fid.create_dataset('exchange/web_camera_frame', data=frame)
-            log.info('The frame was added')
-        else:
-            log.warning('The frame was not added')
-        
-        # Copy raw data to data analysis computer    
-        log.info('Automatic data trasfer to data analysis computer is enabled.')
-        full_file_name = self.epics_pvs['FPFullFileName'].get(as_string=True)
-        remote_analysis_dir = self.epics_pvs['RemoteAnalysisDir'].get(as_string=True)
-        copy_to_analysis_dir = self.epics_pvs['CopyToAnalysisDir'].get()
-        if copy_to_analysis_dir == 1:
-            log.info('Using FDT')
-            dm.fdt_scp(full_file_name, remote_analysis_dir, Path(self.epics_pvs['DetectorTopDir'].get()))
-            self.epics_pvs['ScanStatus'].put('fdt file transfer complete')
-        elif copy_to_analysis_dir == 2:
-            log.info('Using scp')
-            dm.scp(full_file_name, remote_analysis_dir)
-            self.epics_pvs['ScanStatus'].put('scp file transfer complete')
-        else:
-            log.warning('Automatic data trasfer to data analysis computer is disabled.')
-        
+            remote_analysis_dir = self.epics_pvs['RemoteAnalysisDir'].get(as_string=True)
+            copy_to_analysis_dir = self.epics_pvs['CopyToAnalysisDir'].get()
+            if copy_to_analysis_dir == 1:
+                log.info('Using FDT')
+                dm.fdt_scp(full_file_name, remote_analysis_dir, Path(self.epics_pvs['DetectorTopDir'].get()))
+                self.epics_pvs['ScanStatus'].put('fdt file transfer complete')
+            elif copy_to_analysis_dir == 2:
+                log.info('Using scp')
+                dm.scp(full_file_name, remote_analysis_dir)
+                self.epics_pvs['ScanStatus'].put('scp file transfer complete')
+            else:
+                log.warning('Automatic data trasfer to data analysis computer is disabled.')
+        except:
+            log.error('Failed to transfer the scan file to the data analysis computer')
+            traceback.print_exc(file=sys.stdout)
+
         # Call the base class method
         super().end_scan()
         


### PR DESCRIPTION
Companion to the fix in `fix/end-scan-must-not-wedge-startscan`, branched
separately from `master` so the two can be reviewed and merged
independently. That PR stops a raise inside `end_scan()` from killing the
scan thread outright. This one removes the most concrete cause of such a
raise at 2-BM: the two unguarded, best-effort steps this override adds
before calling `super().end_scan()`.

**Mechanism.** `TomoScan2BM.end_scan()` does two things beyond the base
class's own cleanup: it appends a web camera frame to the scan file with
`fid.create_dataset('exchange/web_camera_frame', data=frame)`, and it
copies the finished file to the analysis computer with `dm.fdt_scp()` or
`dm.scp()`. Neither block is guarded. If either raises, `super().end_scan()`
never runs, so `ScanStatus` is never set to its final value, `StartScan` is
never put back to 0, and `scan_is_running` is never cleared. This is
exactly what happened on 2026-08-20: a full disk truncated the scan file,
`create_dataset` raised `ValueError: Unable to synchronously create dataset
(address of object past end of allocation)`, and the scan thread died
before `super().end_scan()` ran.

`add_theta()`, called a few lines earlier in this same method, already
wraps its own hdf5 access in a bare `except` that logs an error and prints
a traceback, on the same reasoning: a problem writing one auxiliary dataset
should not stop the rest of `end_scan()` from completing. `add_theta()`
survived the identical failure on the identical file during the incident.
This gives the webcam-frame block and the data-transfer block the same
guard, each in its own `try/except`, matching `add_theta()`'s style and log
level (`log.error` plus `traceback.print_exc(file=sys.stdout)`).

**Scope.** Only `tomoscan/tomoscan_2bm.py`, only the `end_scan()` method.
The two blocks are each wrapped in a `try/except`; nothing inside either
block changes, and `super().end_scan()` is unchanged. No other method is
touched. The re-indentation needed to wrap the blocks also strips some
trailing whitespace on lines inside them; that is incidental to adding the
guards, not a separate cleanup pass.

**Testing.** This repo has no test coverage of `end_scan()`, and building
an EPICS harness for it is out of scope for this change. To reproduce:
make either block raise (for example, point the credentials file at a
missing path, or force `create_dataset` to fail against a truncated file)
and confirm `super().end_scan()` still runs and `StartScan` reaches 0.
